### PR TITLE
IP address validation added to link regex

### DIFF
--- a/static/chat/css/style.css
+++ b/static/chat/css/style.css
@@ -226,6 +226,9 @@ font-size: 11px;
 .chat-lines a.externallink {
 color: #02C2FF;
 }
+.chat-lines a.externallink.nsfwlink{
+color: #ED1D79;
+}
 .chat-lines a.externallink:visited {
 color: #0088cc;
 }

--- a/static/chat/js/gui.js
+++ b/static/chat/js/gui.js
@@ -33,8 +33,26 @@ function urlReplaceCallback(match, url, scheme, address, path, offset, message) 
 		};
 		return htmlencmap[c];
 	}),
-	linkClass = "externallink";	
+	linkClass = "externallink",
+	contextStart = offset - 10,
+	contextEnd = contextStart + match.length + 20,
+	nsfwregex = /(NSFW|NSFL|SPOILER)/gim;
+	
 	scheme = scheme ? '': 'http://';
+	
+	//Limit context for NSFW/NSFL search to 10 chars (or array bounds) 
+	if (contextStart < 0) {
+		contextStart = 0
+	}
+	
+	if (contextEnd > message.length) {
+		contextEnd = message.length;
+	}
+
+	if (nsfwregex.test(message.substring(contextStart, contextEnd))) {
+		linkClass += " nsfwlink";
+	}
+
 	return match.replace(url, '<a target="_blank" class="' + linkClass + '" href="' + scheme + encodedUrl + '">' + encodedUrl + '</a>');
 }
 


### PR DESCRIPTION
link regex will now only match a valid ipv4 address

Also did some cleanup to the regex' replace callback and grouping.

updated fiddle: http://jsfiddle.net/GMzGy/28/
