### PR TITLE
Chat login message now takes 100% of available width in chat input.

### DIFF
--- a/static/chat/css/style.css
+++ b/static/chat/css/style.css
@@ -374,6 +374,8 @@ display: inline-block;
 
 /* The text shown when a user is not logged in */
 .chat-login-msg {
+display: inline-block;
+width: 100%;
 padding: 0 0 0 5px;
 line-height: 25px;
 color: rgba(255,255,255,0.5);


### PR DESCRIPTION
Should work, but to be fair I've only tested it out with the chrome dev tools on the prod website.
