### PR TITLE
fix url formatter breaking on parentheses in url params

### DIFF
--- a/static/chat/js/formatters.js
+++ b/static/chat/js/formatters.js
@@ -16,20 +16,24 @@
 	
 	// URL line formatter
 	destiny.fn.UrlFormatter = function(chat){
-		var urlchars  = "\\w!\"#$%&'*+,-./:;<=>?@\\\\^`|~", //chars allowed in url path+auth params
-		    tlds      = "(?:AC|AD|AE|AERO|AF|AG|AI|AL|AM|AN|AO|AQ|AR|ARPA|AS|ASIA|AT|AU|AW|AX|AZ|BA|BB|BD|BE|BF|BG|BH|BI|BIZ|BJ|BM|BN|BO|BR|BS|BT|BV|BW|BY|BZ|CA|CAT|CC|CD|CF|CG|CH|CI|CK|CL|CM|CN|CO|COM|COOP|CR|CU|CV|CW|CX|CY|CZ|DE|DJ|DK|DM|DO|DZ|EC|EDU|EE|EG|ER|ES|ET|EU|FI|FJ|FK|FM|FO|FR|GA|GB|GD|GE|GF|GG|GH|GI|GL|GM|GN|GOV|GP|GQ|GR|GS|GT|GU|GW|GY|HK|HM|HN|HR|HT|HU|ID|IE|IL|IM|IN|INFO|INT|IO|IQ|IR|IS|IT|JE|JM|JO|JOBS|JP|KE|KG|KH|KI|KM|KN|KP|KR|KW|KY|KZ|LA|LB|LC|LI|LK|LR|LS|LT|LU|LV|LY|MA|MC|MD|ME|MG|MH|MIL|MK|ML|MM|MN|MO|MOBI|MP|MQ|MR|MS|MT|MU|MUSEUM|MV|MW|MX|MY|MZ|NA|NAME|NC|NE|NET|NF|NG|NI|NL|NO|NP|NR|NU|NZ|OM|ORG|PA|PE|PF|PG|PH|PK|PL|PM|PN|POST|PR|PRO|PS|PT|PW|PY|QA|RE|RO|RS|RU|RW|SA|SB|SC|SD|SE|SG|SH|SI|SJ|SK|SL|SM|SN|SO|SR|ST|SU|SV|SX|SY|SZ|TC|TD|TEL|TF|TG|TH|TJ|TK|TL|TM|TN|TO|TP|TR|TRAVEL|TT|TV|TW|TZ|UA|UG|UK|US|UY|UZ|VA|VC|VE|VG|VI|VN|VU|WF|WS|XXX|YE|YT|ZA|ZM|ZW)",
+		/* chars_reg - chars allowed in basic auth / path parameters
+		 * path_reg - matches valid path params, including matching non-nested parentheses
+		 * tlds - valid TLDs sorted first by length then alphabetically 
+		 * ipregex - matches IP + port in place of url host
+		 * */
+		var chars_reg  = "[\\w!\"#$%&'*+,-./:;<=>?@\\\\^`|~]*",
+			path_reg = "(?:" + chars_reg + "(?:\\(" + chars_reg + "\\))?" + "(?:\\[" + chars_reg + "\\])?" + "(?:\\{" + chars_reg + "\\})?" +  ")*",
+		    tlds      = "(?:MUSEUM|TRAVEL|AERO|ARPA|ASIA|COOP|INFO|JOBS|MOBI|NAME|POST|BIZ|CAT|COM|EDU|GOV|INT|MIL|NET|ORG|PRO|TEL|XXX|AC|AD|AE|AF|AG|AI|AL|AM|AN|AO|AQ|AR|AS|AT|AU|AW|AX|AZ|BA|BB|BD|BE|BF|BG|BH|BI|BJ|BM|BN|BO|BR|BS|BT|BV|BW|BY|BZ|CA|CC|CD|CF|CG|CH|CI|CK|CL|CM|CN|CO|CR|CU|CV|CW|CX|CY|CZ|DE|DJ|DK|DM|DO|DZ|EC|EE|EG|ER|ES|ET|EU|FI|FJ|FK|FM|FO|FR|GA|GB|GD|GE|GF|GG|GH|GI|GL|GM|GN|GP|GQ|GR|GS|GT|GU|GW|GY|HK|HM|HN|HR|HT|HU|ID|IE|IL|IM|IN|IO|IQ|IR|IS|IT|JE|JM|JO|JP|KE|KG|KH|KI|KM|KN|KP|KR|KW|KY|KZ|LA|LB|LC|LI|LK|LR|LS|LT|LU|LV|LY|MA|MC|MD|ME|MG|MH|MK|ML|MM|MN|MO|MP|MQ|MR|MS|MT|MU|MV|MW|MX|MY|MZ|NA|NC|NE|NF|NG|NI|NL|NO|NP|NR|NU|NZ|OM|PA|PE|PF|PG|PH|PK|PL|PM|PN|PR|PS|PT|PW|PY|QA|RE|RO|RS|RU|RW|SA|SB|SC|SD|SE|SG|SH|SI|SJ|SK|SL|SM|SN|SO|SR|ST|SU|SV|SX|SY|SZ|TC|TD|TF|TG|TH|TJ|TK|TL|TM|TN|TO|TP|TR|TT|TV|TW|TZ|UA|UG|UK|US|UY|UZ|VA|VC|VE|VG|VI|VN|VU|WF|WS|YE|YT|ZA|ZM|ZW)",
 		    ipaddr    = "(?:(?:[0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}(?:[0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])";
 		this.linkregex = new RegExp(
-			"(?:^|[\\s\\(\\[])" + //Match valid delimiters for multi URL lines
-			"(((?:https?|ftp):\\/\\/)?" + //Begin URL group, match and group protocol (if any).
-			"(?:[\\w]+(?::[" + urlchars + "]*)?@)?" + //Match basic auth user/password prefix
-			"(?:" + ipaddr + "|(?:"+ // match an ip address or domain
+			"(((?:https?|ftp):\\/\\/)?" + //begin URL group, match protocol (if any)
+			"(?:[\\w]+(?::" + chars_reg + ")?@)?" + //match basic auth user/password prefix
+			"(?:" + ipaddr + "|(?:"+ //match an ip address or domain
 			"(?:[\\w-]+\\.)+" + //match subdomains and domain
 			tlds + //match valid+accepted TLDs, we don't care about punycode
 			"))(?::[0-9]{1,5})?" + //match optional port (16-bit)
-			"(?:\\/[" + urlchars + "]*)?)" + //match path and query, END URL group
-			"(?=$|[\\s\\)\\]])", // Look ahead for valid delimiters
-			"gim"
+			"(?:\\/" + path_reg + ")?)" //match path and query, END URL group
+			,"gi"
 		);
 		return this;
 	}


### PR DESCRIPTION
Fixes #31 (note: ports and & issues were already fixed on master)
I removed the delimiter checks as they just over-complicate this regex, this allows links to be matched in any context.  The expression for the path section now matches non-nested brackets () [] or {}, surrounding the currently allowed characters (uses lookahead)
