### PR TITLE
Opt-in rustlebot and /ignore for chat commands

### DIFF
--- a/static/chat/js/chat.js
+++ b/static/chat/js/chat.js
@@ -441,7 +441,7 @@ chat.prototype.handleCommand = function(str) {
 				this.gui.push(new ChatErrorMessage("Invalid nick - /ignore nick"));
 				return;
 			}
-			var nick = nick.toLowerCase();
+			var nick = parts[1].toLowerCase();
 			if(nickregex.test(nick)){
 				delete(this.ignorelist[nick]);
 				this.gui.push(new ChatStatusMessage(""+nick+" has been removed from your ignore list"));


### PR DESCRIPTION
...s messages and !rustlebot by default

this is a compromise between developing new chat commands and reducing bot spam

let's say you didn't care to know every time someone called !strims for example

you would type:

```
/ignore !strims
```

and now every time someone wrote 

```
!strims
```

, that message would be hidden.

ALSO:

rustlebot is ignored by default, and any calls to !rustlebot are ignored by default

i will modify rustlebot so all of it's messages are prefixed with the calling command, so users may optionally ignore only specific commands, while otherwise not ignoring the bot itself.

TODO: 
- minify and build 
- make sure tests (are there any?) pass

I would need help with those two, since i don't really have a development environment for PHP set up
