### PR TITLE
Load the twitch.tv player using the same protocol as the website

### DIFF
--- a/lib/Resources/views/bigscreen.php
+++ b/lib/Resources/views/bigscreen.php
@@ -20,7 +20,7 @@ use Destiny\Common\Config;
 
         <div id="stream-panel">
             <div id="stream-wrap">
-                <iframe class="stream-element" marginheight="0" marginwidth="0" frameborder="0" src="http://player.twitch.tv/?channel=<?=Config::$a['twitch']['user']?>" scrolling="no" seamless allowfullscreen></iframe>
+                <iframe class="stream-element" marginheight="0" marginwidth="0" frameborder="0" src="//player.twitch.tv/?channel=<?=Config::$a['twitch']['user']?>" scrolling="no" seamless allowfullscreen></iframe>
             </div>
         </div>
 

--- a/lib/Resources/views/seg/livebanner.php
+++ b/lib/Resources/views/seg/livebanner.php
@@ -24,7 +24,7 @@ $isoffline = (!isset($model->streamInfo['stream']) || empty($model->streamInfo['
           <a href="/bigscreen" class="btn btn-lg btn-primary"><i style="margin-top: 2px;" class="icon-bigscreen animated"></i> Watch the live stream</a>
           <div class="banner-popout-links btn-group pull-right" data-toggle="buttons" style="margin-top: 10px;">
             <a target="_blank" class="btn btn-link popup" href="/embed/chat" data-options="<?=Tpl::out('{"height":"500","width":"420"}')?>"><i class="fa fa-comment"></i> Chat</a>
-            <a target="_blank" class="btn btn-link popup" href="http://player.twitch.tv/?channel=<?=Config::$a['twitch']['user']?>" data-options="<?=Tpl::out('{"height":"420","width":"720"}')?>"><i class="fa fa-eye"></i> Stream</a>
+            <a target="_blank" class="btn btn-link popup" href="//player.twitch.tv/?channel=<?=Config::$a['twitch']['user']?>" data-options="<?=Tpl::out('{"height":"420","width":"720"}')?>"><i class="fa fa-eye"></i> Stream</a>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Since twitch.tv supports https now and also the subreddit links to the https version of Destiny.gg, some people have been complaining that the stream doesn't load anymore in chat.

The usual fix was telling them to remove the "s" in the url, so that the player loads correctly, since the "http" protocol is hardcoded at the moment. Apparently default chrome and firefox settings both prohibit embeding the http player into the https website now.
This fix would allow to automatically load the twitch.tv player with a protocol according to the protocol of the website.

The only downside is that people that do not have flash player installed still won't be able to watch on the https website because the hls part of the html5 player is loading video data via http which again results in mixed content.