### PR TITLE
Ignore errors when loading from corrupted localStorage

### DIFF
--- a/static/chat/js/chat.js
+++ b/static/chat/js/chat.js
@@ -100,7 +100,9 @@ chat.prototype.loadIgnoreList = function() {
 	if (!localStorage)
 		return;
 	
-	this.ignorelist = JSON.parse(localStorage['chatignorelist'] || '{}');
+	try {
+		this.ignorelist = JSON.parse(localStorage['chatignorelist'] || '{}');
+	} catch (e) {}
 	this.ignoreregex = null;
 };
 

--- a/static/chat/js/gui.js
+++ b/static/chat/js/gui.js
@@ -646,7 +646,11 @@
         },
 
         getInputHistory: function(){
-            return JSON.parse(localStorage['inputhistory'] || '[]');
+            try {
+                return JSON.parse(localStorage['inputhistory'] || '[]');
+            } catch (e) {
+                return [];
+            }
         },
 
         setInputHistory: function(arr){
@@ -768,13 +772,21 @@
             return false;
         },
 
+        getChatOptions: function() {
+            try {
+                return JSON.parse(localStorage['chatoptions'] || '{}');
+            } catch (e) {
+                return {};
+            }
+        },
+
         getChatOption: function(option, defaultvalue) {
-            var options = JSON.parse(localStorage['chatoptions'] || '{}');
+            var options = this.getChatOptions();
             return (options[option] == undefined)? defaultvalue: options[option];
         },
 
         saveChatOption: function(option, value) {
-            var options     = JSON.parse(localStorage['chatoptions'] || '{}');
+            var options     = this.getChatOptions();
             options[option] = value;
             localStorage['chatoptions'] = JSON.stringify(options);
         },


### PR DESCRIPTION
Somehow my settings key in localStorage got populated with "undefined" which caused chat to crash on startup due to unhandled JSON.parse exceptions... Make it fail silently rather than crashing.