### PR TITLE
Apply highlighting changes immediately

### DIFF
--- a/static/chat/js/chat.js
+++ b/static/chat/js/chat.js
@@ -593,14 +593,16 @@ chat.prototype.handleCommand = function(str) {
 			}
 			
 			nick = parts[1].toLowerCase();
-			if (command == "unhighlight") {
-				delete(highlightnicks[nick]);
-				this.gui.push(new ChatInfoMessage("No longer highlighting: " + nick));
-			} else {
+			dohighlight = command == "highlight";
+			if (dohighlight) {
 				highlightnicks[nick] = true;
 				this.gui.push(new ChatInfoMessage("Now highlighting: " + nick));
+			} else {
+				delete(highlightnicks[nick]);
+				this.gui.push(new ChatInfoMessage("No longer highlighting: " + nick));
 			}
 			
+			this.gui.renewHighlight(nick, dohighlight);
 			this.gui.setPreference('highlightnicks', highlightnicks);
 			break;
 			

--- a/static/chat/js/gui.js
+++ b/static/chat/js/gui.js
@@ -688,6 +688,14 @@
             }
         },
 
+        renewHighlight: function(nick, dohighlight){
+            if (dohighlight){
+                this.lines.children('div[data-username="'+nick.toLowerCase()+'"]').addClass("highlight");
+            } else {
+                this.lines.children('div[data-username="'+nick.toLowerCase()+'"]').removeClass("highlight");
+            }
+        },
+
         handleHighlight: function(message){
             if (!message.user || !message.user.username || message.user.username == this.engine.user.username || !this.getPreference('highlight'))
                 return false;


### PR DESCRIPTION
First attempt to do something useful, this is supposed to fix #112.

It should be considered to make a distinction between different highlight-types. This patch would introduce a "bug" because all highlights are currently equal:
If a user mentions you by nick, and you "/unhighlight" them afterwards, that message will get unhighlighted as well, even though messages that include your nick would be highlighted regardless of highlight-preference.