### PR TITLE
Mark nicks in the backlog as clickable

### DIFF
--- a/static/chat/js/chat.js
+++ b/static/chat/js/chat.js
@@ -593,14 +593,16 @@ chat.prototype.handleCommand = function(str) {
 			}
 			
 			nick = parts[1].toLowerCase();
-			if (command == "unhighlight") {
-				delete(highlightnicks[nick]);
-				this.gui.push(new ChatInfoMessage("No longer highlighting: " + nick));
-			} else {
+			dohighlight = command == "highlight";
+			if (dohighlight) {
 				highlightnicks[nick] = true;
 				this.gui.push(new ChatInfoMessage("Now highlighting: " + nick));
+			} else {
+				delete(highlightnicks[nick]);
+				this.gui.push(new ChatInfoMessage("No longer highlighting: " + nick));
 			}
 			
+			this.gui.renewHighlight(nick, dohighlight);
 			this.gui.setPreference('highlightnicks', highlightnicks);
 			break;
 			

--- a/static/chat/js/chat.js
+++ b/static/chat/js/chat.js
@@ -593,7 +593,7 @@ chat.prototype.handleCommand = function(str) {
 			}
 			
 			nick = parts[1].toLowerCase();
-			dohighlight = command == "highlight";
+			var dohighlight = command == "highlight";
 			if (dohighlight) {
 				highlightnicks[nick] = true;
 				this.gui.push(new ChatInfoMessage("Now highlighting: " + nick));

--- a/static/chat/js/gui.js
+++ b/static/chat/js/gui.js
@@ -468,6 +468,14 @@
                 return;
             }
 
+            // parse backlog preliminarily to initialize nicks so the formatter will mark them as such (clickable)
+            for (var i = 0, j = this.backlog.length; i < j; i++){
+                obj = JSON.parse(this.backlog[i].substring(this.backlog[i].indexOf(' ')));
+                if(obj.nick){
+                    this.engine.users[obj.nick] = "";
+                }
+            }
+
             for (var i = 0, j = this.backlog.length; i < j; i++)
                 this.engine.parseAndDispatch({
                     data: this.backlog[i]

--- a/static/chat/js/gui.js
+++ b/static/chat/js/gui.js
@@ -688,6 +688,14 @@
             }
         },
 
+        renewHighlight: function(nick, dohighlight){
+            if (dohighlight){
+                this.lines.children('div[data-username="'+nick.toLowerCase()+'"]').addClass("highlight");
+            } else {
+                this.lines.children('div[data-username="'+nick.toLowerCase()+'"]').removeClass("highlight");
+            }
+        },
+
         handleHighlight: function(message){
             if (!message.user || !message.user.username || message.user.username == this.engine.user.username || !this.getPreference('highlight'))
                 return false;

--- a/static/chat/js/gui.js
+++ b/static/chat/js/gui.js
@@ -470,10 +470,9 @@
 
             // parse backlog preliminarily to initialize nicks so the formatter will mark them as such (clickable)
             for (var i = 0, j = this.backlog.length; i < j; i++){
-                obj = JSON.parse(this.backlog[i].substring(this.backlog[i].indexOf(' ')));
-                if(obj.nick){
+                var obj = JSON.parse(this.backlog[i].substring(this.backlog[i].indexOf(' ')));
+                if(obj.nick)
                     this.engine.users[obj.nick] = "";
-                }
             }
 
             for (var i = 0, j = this.backlog.length; i < j; i++)


### PR DESCRIPTION
This is a pretty hacky change, but I did not find anything that breaks because of it.

Basically the formatter needs the users-object initialized to highlight nicks. The backlog is however inizialized strictly before the connection to the chat-server is done. The only way to tell what a nick is, is thus to extract that info from the backlog itself.