### PR TITLE
chat: handle empty command

### DIFF
--- a/static/chat/js/chat.js
+++ b/static/chat/js/chat.js
@@ -369,6 +369,11 @@ chat.prototype.onPRIVMSGSENT = function(data) {
 };
 
 chat.prototype.handleCommand = function(str) {
+    // empty command, do not try to parse it
+    if (!str.length) {
+      this.gui.push(new ChatErrorMessage("Empty command"));
+      return;
+    }
 
     var parts     = str.match(/([^ ]+)/g),
         command   = parts[0].toLowerCase(),


### PR DESCRIPTION
Prevents the entire chat page from reloading when a user enters the empty command (simply, "/").

Closes https://github.com/destinygg/website/issues/115