### PR TITLE
Fixed sql error in 'dfl_features'

### DIFF
--- a/config/destiny.gg.data.sql
+++ b/config/destiny.gg.data.sql
@@ -27,4 +27,4 @@ INSERT  INTO `dfl_features`(`featureId`,`featureName`,`featureLabel`) VALUES
   (14, 'flair8', 'Subscriber Tier 4'),
   (15, 'flair10', 'StarCraft 2'),
   (16, 'flair11', 'Bot 2'),
-  (16, 'flair12', 'Broadcaster');
+  (17, 'flair12', 'Broadcaster');


### PR DESCRIPTION
SQL was throwing the "Duplicate entry" error on import, because both "flair11" and "flair12" had the same "featureId"