### PR TITLE
[New feature] Chat: Hall of Fame

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
 	"name" : "destiny/website",
 	"description": "Destiny.gg website",
 	"license": "proprietary",
-	"version": "1.7.14",
+	"version": "1.7.15",
 	"minimum-stability": "dev",
 	"require": {
 		"php" : ">=5.3.0",

--- a/config/destiny.gg.sql
+++ b/config/destiny.gg.sql
@@ -169,3 +169,12 @@ CREATE TABLE `privatemessages` (
   KEY `targetuserid` (`targetuserid`),
   KEY `userid` (`userid`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE TABLE `chat_combos` (
+  `id` INT(10) UNSIGNED NOT NULL AUTO_INCREMENT,
+  `emote` VARCHAR(32) NOT NULL,
+  `combo` INT(10) UNSIGNED NOT NULL,
+  `memers` TEXT NOT NULL,
+  `timestamp` datetime NOT NULL,
+  PRIMARY KEY (`id`), INDEX (`combo`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;

--- a/lib/Destiny/Controllers/ChatAdminController.php
+++ b/lib/Destiny/Controllers/ChatAdminController.php
@@ -27,6 +27,8 @@ class ChatAdminController {
      * @return string
      */
     public function adminChat(ViewModel $model) {
+        $chatIntegrationService = ChatIntegrationService::instance ();
+        $model->totalCombos = $chatIntegrationService->countChatCombos();
         $model->title = 'Chat';
         if (Session::get ( 'modelSuccess' )) {
             $model->success = Session::get ( 'modelSuccess' );
@@ -77,6 +79,42 @@ class ChatAdminController {
         $model->searchIp = $params ['ip'];
         
         return 'admin/chat';
+    }
+
+    /**
+     * @Route ("/admin/chat/removecombos")
+     * @Secure ({"ADMIN"})
+     *
+     * @return string
+     */
+    public function adminChatRemoveCombos(){
+        $chatIntegrationService = ChatIntegrationService::instance ();
+
+        if ($chatIntegrationService->deleteChatCombos()) {
+            Session::set('modelSuccess', 'All chat combos except 10 highest ones have been removed.');
+        } else {
+            Session::set('modelError', 'Something went wrong, check web.log for more info!');
+        }
+
+        return 'redirect: /admin/chat';
+    }
+
+    /**
+     * @Route ("/admin/chat/removeallcombos")
+     * @Secure ({"ADMIN"})
+     *
+     * @return string
+     */
+    public function adminChatRemoveAllCombos(){
+        $chatIntegrationService = ChatIntegrationService::instance ();
+
+        if ($chatIntegrationService->purgeChatCombos()) {
+            Session::set('modelSuccess', 'Every single chat combo has been removed.');
+        } else {
+            Session::set('modelError', 'Something went wrong, check web.log for more info!');
+        }
+
+        return 'redirect: /admin/chat';
     }
 
 }

--- a/lib/Destiny/Controllers/ChatController.php
+++ b/lib/Destiny/Controllers/ChatController.php
@@ -4,6 +4,7 @@ namespace Destiny\Controllers;
 use Destiny\Common\Session;
 use Destiny\Common\User\UserRole;
 use Destiny\Common\ViewModel;
+use Destiny\Common\Application;
 use Destiny\Common\Annotation\Controller;
 use Destiny\Common\Annotation\Route;
 use Destiny\Common\Response;
@@ -27,6 +28,26 @@ class ChatController {
     public function faq(ViewModel $model) {
         $model->title = 'Frequently Asked Questions';
         return 'chat/faq';
+    }
+
+    /**
+     * @Route ("/chat/halloffame")
+     *
+     * @param ViewModel $model
+     * @return string
+     */
+    public function halloffame(ViewModel $model) {
+        $chatIntegrationService = ChatIntegrationService::instance();
+        $combos = Application::instance()->getCacheDriver()->fetch('chatcombos');
+
+        $username = $this->getChatUser()['nick'];
+        if (!empty($username)) {
+            $model->myCombos = $chatIntegrationService->getMyChatCombos($username);
+        }
+        $model->title = 'Hall of Fame';
+        $model->topCombos = $combos['top'];
+        $model->recentCombos = $combos['recent'];
+        return 'chat/halloffame';
     }
 
     /**

--- a/lib/Destiny/Tasks/HallOfFameFeed.php
+++ b/lib/Destiny/Tasks/HallOfFameFeed.php
@@ -1,0 +1,22 @@
+<?php
+namespace Destiny\Tasks;
+
+use Destiny\Common\Annotation\Schedule;
+use Destiny\Common\Application;
+use Destiny\Common\TaskInterface;
+use Destiny\Chat\ChatIntegrationService;
+
+/**
+ * @Schedule(frequency=1,period="minute")
+ */
+class HallOfFameFeed implements TaskInterface {
+
+    public function execute() {
+        $chatIntegrationService = ChatIntegrationService::instance();
+        $response['top'] = $chatIntegrationService->getChatCombos();
+        $response['recent'] = $chatIntegrationService->getChatCombos(true);
+        if (!empty($response))
+            Application::instance()->getCacheDriver()->save('chatcombos', $response);
+    }
+
+}

--- a/lib/Resources/views/admin/chat.php
+++ b/lib/Resources/views/admin/chat.php
@@ -97,6 +97,24 @@ use Destiny\Common\Utils\Date;
             </div>
         </section>
         <?php endif; ?>
+
+        <section class="container">
+            <h3>Hall of Fame</h3>
+            <div class="content content-dark clearfix">
+                <div class="ds-block">
+                    <?php if(!empty($model->totalCombos)): ?>
+                        <label>Number of stored chat combos in the database: <?=Tpl::out($model->totalCombos)?></label>
+                        <p>This will remove all chat combos except 10 highest ones.</p>
+                        <a href="/admin/chat/removecombos" onclick="return confirm('Are you sure?');" class="btn btn-warning">Remove</a>
+                        <br><br>
+                        <p>This will remove every single chat combo.</p>
+                        <a href="/admin/chat/removeallcombos" onclick="return confirm('Are you sure?');" class="btn btn-danger">Remove All</a>
+                    <?php else: ?>
+                        <label>We couldn't find any chat combos in the database.</label>
+                    <?php endif; ?>
+                </div>
+            </div>
+        </section>
     </div>
 
     <?php include Tpl::file('seg/foot.php') ?>

--- a/lib/Resources/views/chat/halloffame.php
+++ b/lib/Resources/views/chat/halloffame.php
@@ -13,6 +13,9 @@ use Destiny\Common\Utils\Date;
     <?php include Tpl::file('seg/commontop.php') ?>
     <?php include Tpl::file('seg/google.tracker.php') ?>
     <link href="<?=Config::cdnv()?>/chat/css/style.min.css" rel="stylesheet" media="screen">
+    <style>
+        .combo-margin {margin-top: 2px; margin-bottom: 2px;}
+    </style>
 </head>
 <body id="emoticons" class="no-brand">
 <div id="page-wrap">
@@ -48,7 +51,7 @@ use Destiny\Common\Utils\Date;
                             <a class="label label-default" data-memers="<?=$trigger['memers']?>">Memers</a>
                         </td>
                         <td>
-                            <div id="chat-lines" style="margin-top: 2px; margin-bottom: 2px;">
+                            <div id="chat-lines" class="combo-margin">
                                 <div class="emotecount <?=calcStepClass($trigger['combo'])?>"><i class="count"><?=Tpl::out($trigger['combo'])?></i><i class="x">X</i> C-C-C-COMBO</div>
                                 <div style="display: inline-block" class="chat-emote chat-emote-<?=$trigger['emote']?>" data-placement="right" data-toggle="tooltip" title="<?=$trigger['emote']?>"></div>
                             </div>
@@ -67,7 +70,7 @@ use Destiny\Common\Utils\Date;
                             <a class="label label-default" data-memers="<?=$trigger['memers']?>">Memers</a>
                         </td>
                         <td>
-                            <div id="chat-lines" style="margin-top: 2px; margin-bottom: 2px;">
+                            <div id="chat-lines" class="combo-margin">
                                 <div class="emotecount <?=calcStepClass($trigger['combo'])?>"><i class="count"><?=Tpl::out($trigger['combo'])?></i><i class="x">X</i> C-C-C-COMBO</div>
                                 <div style="display: inline-block" class="chat-emote chat-emote-<?=$trigger['emote']?>" data-placement="right" data-toggle="tooltip" title="<?=$trigger['emote']?>"></div>
                             </div>
@@ -87,7 +90,7 @@ use Destiny\Common\Utils\Date;
                                 <a class="label label-default" data-memers="<?=$trigger['memers']?>">Memers</a>
                             </td>
                             <td>
-                                <div id="chat-lines" style="margin-top: 2px; margin-bottom: 2px;">
+                                <div id="chat-lines" class="combo-margin">
                                     <div class="emotecount <?=calcStepClass($trigger['combo'])?>"><i class="count"><?=Tpl::out($trigger['combo'])?></i><i class="x">X</i> C-C-C-COMBO</div>
                                     <div style="display: inline-block" class="chat-emote chat-emote-<?=$trigger['emote']?>" data-placement="right" data-toggle="tooltip" title="<?=$trigger['emote']?>"></div>
                                 </div>

--- a/lib/Resources/views/chat/halloffame.php
+++ b/lib/Resources/views/chat/halloffame.php
@@ -1,0 +1,129 @@
+<?php
+namespace Destiny;
+use Destiny\Common\Config;
+use Destiny\Common\Utils\Tpl;
+use Destiny\Common\Utils\Date;
+?>
+<!DOCTYPE html>
+<html>
+<head>
+    <title><?=Tpl::title($model->title)?></title>
+    <meta charset="utf-8">
+    <?php include Tpl::file('seg/opengraph.php') ?>
+    <?php include Tpl::file('seg/commontop.php') ?>
+    <?php include Tpl::file('seg/google.tracker.php') ?>
+    <link href="<?=Config::cdnv()?>/chat/css/style.min.css" rel="stylesheet" media="screen">
+</head>
+<body id="emoticons" class="no-brand">
+<div id="page-wrap">
+
+    <?php include Tpl::file('seg/top.php') ?>
+    <?php include Tpl::file('seg/headerband.php') ?>
+    <?php function calcStepClass($combo) {
+        $stepClass = '';
+        if($combo >= 50)
+            $stepClass = ' x50';
+        else if($combo >= 30)
+            $stepClass = ' x30';
+        else if($combo >= 20)
+            $stepClass = ' x20';
+        else if($combo >= 10)
+            $stepClass = ' x10';
+        else if($combo >= 5)
+            $stepClass = ' x5';
+
+        return $stepClass;
+    } ?>
+
+    <section class="container">
+        <h1 class="title">Hall of Fame</h1>
+        <hr size="1">
+        <div class="col-md-4">
+            <h4>[ Highest Combos ]</h4>
+            <table>
+                <?php foreach( $model->topCombos as $trigger ): ?>
+                    <?php $time = Date::getElapsedTime(Date::getDateTime($trigger['timestamp'])) ?>
+                    <tr data-placement="left" data-toggle="tooltip" title="<?=$time?>">
+                        <td>
+                            <a class="label label-default" data-memers="<?=$trigger['memers']?>">Memers</a>
+                        </td>
+                        <td>
+                            <div id="chat-lines" style="margin-top: 2px; margin-bottom: 2px;">
+                                <div class="emotecount <?=calcStepClass($trigger['combo'])?>"><i class="count"><?=Tpl::out($trigger['combo'])?></i><i class="x">X</i> C-C-C-COMBO</div>
+                                <div style="display: inline-block" class="chat-emote chat-emote-<?=$trigger['emote']?>" data-placement="right" data-toggle="tooltip" title="<?=$trigger['emote']?>"></div>
+                            </div>
+                        </td>
+                    </tr>
+                <?php endforeach; ?>
+            </table>
+        </div>
+        <div class="col-md-4">
+            <h4>[ Recent Combos ]</h4>
+            <table>
+                <?php foreach( $model->recentCombos as $trigger ): ?>
+                    <?php $time = Date::getElapsedTime(Date::getDateTime($trigger['timestamp'])) ?>
+                    <tr data-placement="left" data-toggle="tooltip" title="<?=$time?>">
+                        <td>
+                            <a class="label label-default" data-memers="<?=$trigger['memers']?>">Memers</a>
+                        </td>
+                        <td>
+                            <div id="chat-lines" style="margin-top: 2px; margin-bottom: 2px;">
+                                <div class="emotecount <?=calcStepClass($trigger['combo'])?>"><i class="count"><?=Tpl::out($trigger['combo'])?></i><i class="x">X</i> C-C-C-COMBO</div>
+                                <div style="display: inline-block" class="chat-emote chat-emote-<?=$trigger['emote']?>" data-placement="right" data-toggle="tooltip" title="<?=$trigger['emote']?>"></div>
+                            </div>
+                        </td>
+                    </tr>
+                <?php endforeach; ?>
+            </table>
+        </div>
+        <div class="col-md-4">
+            <h4>[ My Combos ]</h4>
+            <?php if(isset($model->myCombos)): ?>
+                <table>
+                    <?php foreach( $model->myCombos as $trigger ): ?>
+                        <?php $time = Date::getElapsedTime(Date::getDateTime($trigger['timestamp'])) ?>
+                        <tr data-placement="left" data-toggle="tooltip" title="<?=$time?>">
+                            <td>
+                                <a class="label label-default" data-memers="<?=$trigger['memers']?>">Memers</a>
+                            </td>
+                            <td>
+                                <div id="chat-lines" style="margin-top: 2px; margin-bottom: 2px;">
+                                    <div class="emotecount <?=calcStepClass($trigger['combo'])?>"><i class="count"><?=Tpl::out($trigger['combo'])?></i><i class="x">X</i> C-C-C-COMBO</div>
+                                    <div style="display: inline-block" class="chat-emote chat-emote-<?=$trigger['emote']?>" data-placement="right" data-toggle="tooltip" title="<?=$trigger['emote']?>"></div>
+                                </div>
+                            </td>
+                        </tr>
+                    <?php endforeach; ?>
+                </table>
+            <?php else: ?>
+                <p>You must <a href="/login" target="_parent">sign in</a> to see your combos.</p>
+            <?php endif; ?>
+        </div>
+        <div class="row"></div>
+        <div class="col-md-12">
+            <h4>[ Memers ]</h4>
+            <p id="memers" style="word-wrap: break-word"></p>
+        </div>
+    </section>
+
+</div>
+
+<?php include Tpl::file('seg/foot.php') ?>
+<?php include Tpl::file('seg/commonbottom.php') ?>
+<script>
+    (function(){
+        var prevElement = null;
+        $('.label').click(function() {
+            if (prevElement != null) {
+                prevElement.removeClass('label-success');
+            }
+
+            $(this).addClass('label-success');
+            $('#memers').html($(this).data('memers'));
+            prevElement = $(this);
+        });
+    })();
+</script>
+
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Destiny",
-  "version": "1.7.14",
+  "version": "1.7.15",
   "description": "Destiny.gg front-end",
   "main": "GruntFile.js",
   "scripts": {


### PR DESCRIPTION
This feature takes previously recorded emote combos from database and displays the highest ones in a view located at “/chat/halloffame” alongside combos you participated in and the most recent ones.

Here is a preview showing how this looks like: [YouTube Clip](https://youtu.be/L2XHU76Xw0w)
The code responsible for saving emote combos from chat to database is located [here](https://github.com/Davy1992/combotracker).

I've created this pull request to get some feedback regarding the underlying code and design.