### PR TITLE
Correctly report when stream is hosted

### DIFF
--- a/static/web/js/ui.js
+++ b/static/web/js/ui.js
@@ -367,7 +367,7 @@ $(function(){
         };
 
         var updateStatus = function(status){
-            var state = (status['host'] && status.host['target_id'] !== undefined) ? 'hosting' : (status.live ? 'online':'offline');
+            var state = (status['host'] && status.host['id'] !== undefined) ? 'hosting' : (status.live ? 'online':'offline');
             el.removeClass('online offline hosting').addClass(state);
             end.text(moment(status.ended_at).fromNow());
             start.text(moment(status.started_at).fromNow());


### PR DESCRIPTION
stream.json will contain the host's id in host['id'], not host['target_id'].

https://github.com/destinygg/website/blob/14b40fbb1abb280e5848a6aca663439927481118/lib/Destiny/Twitch/TwitchApiService.php#L68
https://github.com/destinygg/website/blob/14b40fbb1abb280e5848a6aca663439927481118/lib/Destiny/Tasks/StreamInfo.php#L34