### PR TITLE
Update chat.js

### DIFF
--- a/assets/chat/js/chat.js
+++ b/assets/chat/js/chat.js
@@ -1205,7 +1205,7 @@ class Chat {
                     const date = moment.utc(d[d.length-1].date*1000).local().format(DATE_FORMATS.FULL);
                     MessageBuilder.info(`Mentions for ${parts[0]} last seen ${date}`).into(this);
                     d.forEach(a => MessageBuilder.historical(a.text, new ChatUser(a.nick), a.date*1000).into(this))
-                    MessageBuilder.info(`End of stalk (https://dgg.overrustlelogs.net/${parts[0]})`).into(this);
+                    MessageBuilder.info(`End of stalk (https://dgg.overrustlelogs.net/mentions/${parts[0]})`).into(this);
                 }
             })
             .fail(e => MessageBuilder.error(`No mentions for ${parts[0]} received. Try again later`).into(this));


### PR DESCRIPTION
/mention command should now link to https://dgg.overrustlelogs.net/mentions/ instead of https://dgg.overrustlelogs.net/
but I dunno I just made this change in github and didn't even build it