### PR TITLE
Fixes https://github.com/destinygg/chat/issues/31

### DIFF
--- a/lib/Destiny/Common/Utils/FilterParams.php
+++ b/lib/Destiny/Common/Utils/FilterParams.php
@@ -54,7 +54,7 @@ abstract class FilterParams {
      * @return bool
      */
     public static function isEmpty(array $params, $identifier) {
-        if (!is_array($params) || !isset ($params [$identifier]) || empty ($params [$identifier]) || trim($params [$identifier]) == '') {
+        if (!is_array($params) || !isset ($params [$identifier]) || strlen ($params [$identifier]) == 0 || trim($params [$identifier]) == '') {
             return true;
         }
         return false;


### PR DESCRIPTION
You can read the issue for context. Essentially `empty` in PHP will return `true` for the string `"0"`. This prevents users from being able to send `"0"` as a private message: https://github.com/destinygg/website/blob/37795a27dbc6c7b04f202db1b56bc53081b2aafb/lib/Destiny/Controllers/PrivateMessageController.php#L62

The change I'm proposing is to not use `empty` and instead use `strlen (...) == 0`. This does _basically_ the same thing, but gets around PHP's weird some truthiness for values (I'm not familiar with PHP so maybe it's not weird 🤷‍♀️). `strlen` _can_ throw an exception if provided a `null` value, but since we check `isset` before checking `strlen` this shouldn't be a problem. 

Let me know what you think.