### PR TITLE
Fix issue with serving fonts from CDN

### DIFF
--- a/config/nginx/dgg.conf
+++ b/config/nginx/dgg.conf
@@ -54,7 +54,7 @@ server {
 
     rewrite ^/\d+\.\d+\.\d+/(.*)$ /$1;
     location ~ ^/\. { deny  all; }
-    location ~* \.(jpg|jpeg|png|gif|ico|css|js|map|svg)$ {
+    location ~* \.(eot|jpe?g|png|gif|ico|css|js|map|svg|ttf|woff2?)$ {
         expires 365d;
     }
 
@@ -77,7 +77,7 @@ server {
 
     rewrite ^/\d+\.\d+\.\d+/(.*)$ /$1;
     location ~ ^/\. { deny  all; }
-    location ~* \.(jpg|jpeg|png|gif|ico|css|js|map|svg)$ {
+    location ~* \.(eot|jpe?g|png|gif|ico|css|js|map|svg|ttf|woff2?)$ {
         expires 365d;
     }
 
@@ -169,7 +169,7 @@ server {
 
     rewrite ^/\d+\.\d+\.\d+/(.*)$ /$1;
     location ~ ^/\. { deny  all; }
-    location ~* \.(jpg|jpeg|png|gif|ico|css|js|map|svg)$ {
+    location ~* \.(eot|jpe?g|png|gif|ico|css|js|map|svg|ttf|woff2?)$ {
         expires 365d;
     }
 


### PR DESCRIPTION
Requests for font files in `/static/fonts` are captured by [this location block](https://github.com/destinygg/website/blob/9628c10252ca7608a24b98448c207d99a62c5722/config/nginx/dgg.conf#L84-L86) and mistakenly redirected to the web server, which results an error complaining about a missing `Access-Control-Allow-Origin` header.

![nginx cdn config error](https://user-images.githubusercontent.com/20373896/80923991-7bedf280-8d3b-11ea-88ba-f2980c209f35.png)
`http://localhost:8080` is the web server with root `/public` and `http://localhost:8081` is the CDN with root `/static`.

Instead, [this location block](https://github.com/destinygg/website/blob/9628c10252ca7608a24b98448c207d99a62c5722/config/nginx/dgg.conf#L80-L82) should capture the request so NGINX can return the file and properly add `Expires` and `Cache-Control` headers. Adding the font file extensions to the regex definition of the block solves the issue.