### PR TITLE
Fix megaNuke not showing all banned users

### DIFF
--- a/lib/Destiny/Chat/ChatBanService.php
+++ b/lib/Destiny/Chat/ChatBanService.php
@@ -183,7 +183,6 @@ class ChatBanService extends Service {
                     ) AND
                     b.userid       = u.userId AND
                     b.targetuserid = tu.userId
-                GROUP BY b.starttimestamp
                 ORDER BY b.id DESC
             ");
             $stmt->execute();


### PR DESCRIPTION
Why does this group by the start timestamp, that does not make sense. A group by is an aggregation function, this basically is grouping all the things with the same start timestamp into a single record.

Pretty sure this fixes the mega nuke thing.

Either this, or changing the groupBy to groupBy u.username.