### PR TITLE
Fulfill OAuth token requirements for Twitch Helix Webhook API

### DIFF
--- a/lib/Destiny/Common/Authentication/AuthenticationHandler.php
+++ b/lib/Destiny/Common/Authentication/AuthenticationHandler.php
@@ -11,6 +11,8 @@ interface AuthenticationHandler {
     function renewToken(string $refreshToken): array;
 
     /**
+     * Exchange an OAuth code for a user access token.
+     *
      * @throws Exception
      */
     function exchangeCode(array $params): OAuthResponse;

--- a/lib/Destiny/Twitch/TwitchAuthHandler.php
+++ b/lib/Destiny/Twitch/TwitchAuthHandler.php
@@ -125,4 +125,21 @@ class TwitchAuthHandler extends AbstractAuthHandler {
         // TODO Implement
     }
 
+    /**
+     * Validates a token using the `/validate` OAuth endpoint. A response with
+     * status code `200` indicates the token is valid.
+     *
+     * @see https://dev.twitch.tv/docs/authentication/#validating-requests
+     */
+    function validateToken(string $accessToken): bool {
+        $client = $this->getHttpClient();
+        $response = $client->get("$this->authBase/validate", [
+            'headers' => [
+                'User-Agent' => Config::userAgent(),
+                'Authorization' => 'OAuth ' . $accessToken
+            ]
+        ]);
+
+        return $response->getStatusCode() == Http::STATUS_OK;
+    }
 }

--- a/lib/boot.app.php
+++ b/lib/boot.app.php
@@ -11,7 +11,7 @@ use Monolog\Handler\StreamHandler;
 use Monolog\Logger;
 use Monolog\Processor\PsrLogMessageProcessor;
 
-define('_APP_VERSION', '2.14.0'); // auto-generated: 1588552391643
+define('_APP_VERSION', '2.14.1'); // auto-generated: 1589506413539
 define('_BASEDIR', realpath(__DIR__ . '/../'));
 
 $loader = require _BASEDIR . '/vendor/autoload.php';

--- a/lib/boot.test.php
+++ b/lib/boot.test.php
@@ -8,7 +8,7 @@ use Monolog\Handler\StreamHandler;
 use Monolog\Logger;
 use Monolog\Processor\PsrLogMessageProcessor;
 
-define('_APP_VERSION', '2.14.0'); // auto-generated: 1588552391647
+define('_APP_VERSION', '2.14.1'); // auto-generated: 1589506413544
 define('_BASEDIR', realpath(__DIR__ . '/../'));
 
 $loader = require _BASEDIR . '/vendor/autoload.php';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dgg-website",
-  "version": "2.14.0",
+  "version": "2.14.1",
   "description": "Destiny.gg front-end",
   "main": "destiny",
   "scripts": {


### PR DESCRIPTION
This PR closes #181.

Webhook subscriptions in `TwitchWebHookService` now pass an app access token in the request. The token is cached in Redis and a new one is fetched automatically if it expires.

I modified `TwitchAuthHandler->getToken()` to require `grant_type` as a parameter. The value of `grant_type` determines what kind of token is returned: `authorization_code` for a user token and `client_credentials` for an app token.

Fetching a user token using an OAuth code should only ever done through `TwitchAuthHandler->codeExchange()`, so I overrode this function to add `authorization_code` as a param before it does anything else.