### PR TITLE
Fix role filtering

### DIFF
--- a/lib/boot.app.php
+++ b/lib/boot.app.php
@@ -11,7 +11,7 @@ use Monolog\Handler\StreamHandler;
 use Monolog\Logger;
 use Monolog\Processor\PsrLogMessageProcessor;
 
-define('_APP_VERSION', '2.14.1'); // auto-generated: 1589506413539
+define('_APP_VERSION', '2.14.2'); // auto-generated: 1590563171206
 define('_BASEDIR', realpath(__DIR__ . '/../'));
 
 $loader = require _BASEDIR . '/vendor/autoload.php';

--- a/lib/boot.test.php
+++ b/lib/boot.test.php
@@ -8,7 +8,7 @@ use Monolog\Handler\StreamHandler;
 use Monolog\Logger;
 use Monolog\Processor\PsrLogMessageProcessor;
 
-define('_APP_VERSION', '2.14.1'); // auto-generated: 1589506413544
+define('_APP_VERSION', '2.14.2'); // auto-generated: 1590563171212
 define('_BASEDIR', realpath(__DIR__ . '/../'));
 
 $loader = require _BASEDIR . '/vendor/autoload.php';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dgg-website",
-  "version": "2.14.1",
+  "version": "2.14.2",
   "description": "Destiny.gg front-end",
   "main": "destiny",
   "scripts": {

--- a/views/admin/users.php
+++ b/views/admin/users.php
@@ -42,7 +42,7 @@ use Destiny\Common\Utils\Date;
                         <select name="role" class="form-control">
                             <option value="" <?=(!$this->role ? 'selected':'')?>>Any</option>
                             <?php foreach ($this->roles as $role): ?>
-                                <option <?=($role['roleName'] == $this->role) ? 'selected':''?> value="<?=Tpl::out($role['roleName'])?>"><?=Tpl::out($role['roleLabel'])?></option>
+                                <option <?=($role['roleId'] == $this->role) ? 'selected':''?> value="<?=Tpl::out($role['roleId'])?>"><?=Tpl::out($role['roleLabel'])?></option>
                             <?php endforeach; ?>
                         </select>
                     </div>


### PR DESCRIPTION
Filtering users by role on the `/admin/users` page doesn't work because selecting a role mistakenly passes the role's name in the request when it should pass the role's ID. The function that builds the query [expects to receive the ID](https://github.com/destinygg/website/blob/ea316c7d398991c9602a66f7e4a982f79c7780c3/lib/Destiny/Common/User/UserService.php#L297-L299).