### PR TITLE
Follow new Twitch player embed requirements

### DIFF
--- a/assets/web/js/bigscreen.js
+++ b/assets/web/js/bigscreen.js
@@ -125,7 +125,8 @@ import $ from 'jquery'
         title: 'Bigscreen',
         name: streamWrap.data('name'),
         id: null,
-        url: '/bigscreen'
+        url: '/bigscreen',
+        parents: streamWrap.data('twitch-parents')
     }
 
     const streamInfo = {live: false, host: null, preview: null},
@@ -142,13 +143,13 @@ import $ from 'jquery'
         let src = ''
         switch(embedInfo.platform) {
             case 'twitch':
-                src = 'https://player.twitch.tv/?channel=' + encodeURIComponent(embedInfo.name)
+                src = 'https://player.twitch.tv/?' + $.param({ channel: embedInfo.name, parent: embedInfo.parents }, true)
                 break;
             case 'twitch-vod':
-                src = 'https://player.twitch.tv/?video=' + encodeURIComponent(embedInfo.name)
+                src = 'https://player.twitch.tv/?' + $.param({ video: embedInfo.name, parent: embedInfo.parents }, true)
                 break;
             case 'twitch-clip':
-                src = 'https://clips.twitch.tv/embed?clip=' + encodeURIComponent(embedInfo.name)
+                src = 'https://clips.twitch.tv/embed?' + $.param({ clip: embedInfo.name, parent: embedInfo.parents }, true)
                 break;
             case 'youtube':
                 src = 'https://www.youtube.com/embed/' + encodeURIComponent(embedInfo.name)

--- a/assets/web/js/bigscreen.js
+++ b/assets/web/js/bigscreen.js
@@ -117,8 +117,18 @@ import $ from 'jquery'
     const initUrl = document.location.href // important this is stored before any work is done that may change this value
     let streamframe = $body.find('#stream-panel iframe')
     const hashregex = /^#(twitch|twitch-vod|twitch-clip|youtube)\/([A-z0-9_\-]{3,64})$/
+
+    const streamWrap = $body.find('#stream-wrap')
+    const embedInfo = {
+        embed: false,
+        platform: streamWrap.data('platform'),
+        title: 'Bigscreen',
+        name: streamWrap.data('name'),
+        id: null,
+        url: '/bigscreen'
+    }
+
     const streamInfo = {live: false, host: null, preview: null},
-        embedInfo = {embed: false, platform: 'twitch', title: 'Bigscreen', name: 'destiny', id: null, url: '/bigscreen'},
         defaultEmbedInfo = Object.assign({}, embedInfo),
         navpillclasses = ['embedded','hidden','hosting','online','offline'],
         navhostpill = {container: $body.find('#nav-host-pill')},

--- a/config/config.dgg.php
+++ b/config/config.dgg.php
@@ -9,7 +9,7 @@ return [
     'support_email' => 'steven.bonnell.ii@gmail.com',
     'calendar'      => 'i54j4cu9pl4270asok3mqgdrhk@group.calendar.google.com',
     'commerce'      => ['receiver_email' => 'Steven.Bonnell.II@GMail.com'],
-    'embed'         => ['stream' => 'https://player.twitch.tv/?channel=destiny'],
+    'embed'         => ['stream' => ['platform' => 'twitch', 'name' => 'destiny']],
     'reddit'        => ['threads' => 'https://www.reddit.com/r/destiny/hot.json'],
     'blog'          => ['feed' => 'https://blog.destiny.gg/feed/json'],
     'android'       => ['app' => 'gg.destiny.app.chat'],

--- a/config/config.dgg.php
+++ b/config/config.dgg.php
@@ -9,7 +9,7 @@ return [
     'support_email' => 'steven.bonnell.ii@gmail.com',
     'calendar'      => 'i54j4cu9pl4270asok3mqgdrhk@group.calendar.google.com',
     'commerce'      => ['receiver_email' => 'Steven.Bonnell.II@GMail.com'],
-    'embed'         => ['stream' => ['platform' => 'twitch', 'name' => 'destiny']],
+    'embed'         => ['stream' => ['platform' => 'twitch', 'name' => 'destiny', 'twitchParents' => ['www.destiny.gg']]],
     'reddit'        => ['threads' => 'https://www.reddit.com/r/destiny/hot.json'],
     'blog'          => ['feed' => 'https://blog.destiny.gg/feed/json'],
     'android'       => ['app' => 'gg.destiny.app.chat'],

--- a/config/config.php
+++ b/config/config.php
@@ -20,7 +20,8 @@ return [
     'embed' => [
         'stream' => [
             'platform' => '',
-            'name' => ''
+            'name' => '',
+            'twitchParents' => [] // Domains that will embed the stream, e.g., 'www.example.com'. See https://discuss.dev.twitch.tv/t/twitch-embedded-player-updates-in-2020/23956 for more details.
         ],
         'chat' => '/embed/chat'
     ],

--- a/config/config.php
+++ b/config/config.php
@@ -18,7 +18,10 @@ return [
     'allowImpersonation' => false,  // MUST BE OFF ON LIVE AT ALL TIMES. usage: /impersonate?user=Cene or /impersonate?userId=12
 
     'embed' => [
-        'stream' => '',
+        'stream' => [
+            'platform' => '',
+            'name' => ''
+        ],
         'chat' => '/embed/chat'
     ],
 

--- a/lib/Destiny/Common/Utils/Tpl.php
+++ b/lib/Destiny/Common/Utils/Tpl.php
@@ -22,6 +22,16 @@ class Tpl {
         return number_format($number);
     }
 
+    /**
+     * JSON-encodes and sanitizes an array for use in a `data-*` attribute.
+     */
+    public static function arrayOut(array $rawArray): string {
+        $encodedArray = json_encode($rawArray);
+        $sanitizedArray = htmlentities($encodedArray, ENT_QUOTES, 'UTF-8');
+
+        return $sanitizedArray;
+    }
+
     public static function title($title): string {
         $title = trim("$title");
         if (!empty($title)) {

--- a/lib/boot.app.php
+++ b/lib/boot.app.php
@@ -11,7 +11,7 @@ use Monolog\Handler\StreamHandler;
 use Monolog\Logger;
 use Monolog\Processor\PsrLogMessageProcessor;
 
-define('_APP_VERSION', '2.14.2'); // auto-generated: 1590563171206
+define('_APP_VERSION', '2.14.3'); // auto-generated: 1592080470739
 define('_BASEDIR', realpath(__DIR__ . '/../'));
 
 $loader = require _BASEDIR . '/vendor/autoload.php';

--- a/lib/boot.test.php
+++ b/lib/boot.test.php
@@ -8,7 +8,7 @@ use Monolog\Handler\StreamHandler;
 use Monolog\Logger;
 use Monolog\Processor\PsrLogMessageProcessor;
 
-define('_APP_VERSION', '2.14.2'); // auto-generated: 1590563171212
+define('_APP_VERSION', '2.14.3'); // auto-generated: 1592080470744
 define('_BASEDIR', realpath(__DIR__ . '/../'));
 
 $loader = require _BASEDIR . '/vendor/autoload.php';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dgg-website",
-  "version": "2.14.2",
+  "version": "2.14.3",
   "description": "Destiny.gg front-end",
   "main": "destiny",
   "scripts": {

--- a/views/bigscreen.php
+++ b/views/bigscreen.php
@@ -17,8 +17,8 @@ use Destiny\Common\Config;
 
     <div id="bigscreen-layout">
         <div id="stream-panel">
-            <div id="stream-wrap">
-                <iframe seamless="seamless" src="<?= Config::$a['embed']['stream'] ?>" allowfullscreen></iframe>
+            <div id="stream-wrap" data-platform="<?= Config::$a['embed']['stream']['platform'] ?>" data-name="<?= Config::$a['embed']['stream']['name'] ?>">
+                <iframe seamless="seamless" allowfullscreen></iframe>
             </div>
         </div>
         <div id="chat-panel">

--- a/views/bigscreen.php
+++ b/views/bigscreen.php
@@ -17,7 +17,7 @@ use Destiny\Common\Config;
 
     <div id="bigscreen-layout">
         <div id="stream-panel">
-            <div id="stream-wrap" data-platform="<?= Config::$a['embed']['stream']['platform'] ?>" data-name="<?= Config::$a['embed']['stream']['name'] ?>">
+            <div id="stream-wrap" data-platform="<?= Config::$a['embed']['stream']['platform'] ?>" data-name="<?= Config::$a['embed']['stream']['name'] ?>" data-twitch-parents="<?= Tpl::arrayOut(Config::$a['embed']['stream']['twitchParents']) ?>">
                 <iframe seamless="seamless" allowfullscreen></iframe>
             </div>
         </div>


### PR DESCRIPTION
Embedding Twitch's player in an `iframe` now requires a parameter called `parent` in the source URL where the value is the domain that's embedding the player. [Source](https://discuss.dev.twitch.tv/t/twitch-embedded-player-updates-in-2020/23956)

The [`embed['stream']` key in `config.php`](https://github.com/destinygg/website/blob/eddfdc733b8109854b4a9fe29bd793b10060bab6/config/config.dgg.php#L12) stores an embed URL that hasn't been used since the Host Pill was introduced, so changing it has no effect. The source URL for the stream `iframe` on `/bigscreen` is [immediately updated with JS](https://github.com/destinygg/website/blob/eddfdc733b8109854b4a9fe29bd793b10060bab6/assets/web/js/bigscreen.js#L247) using hardcoded values from [`embedInfo`](https://github.com/destinygg/website/blob/eddfdc733b8109854b4a9fe29bd793b10060bab6/assets/web/js/bigscreen.js#L121).

This PR modifies `embed['stream']` to store three values. Two of these values correspond to properties of `embedInfo`, `platform` and `name`, and one value is an array used build the new `parent` parameter. This setup lets you specify your own values for `parent` without having to modify the source.

There are a few different ways I could have accessed `config.php` values in `bigscreen.js`. I ultimately went with an approach that uses `data-*` attributes as middlemen.