### PR TITLE
Fix exception that occurs when no auth profile URL exists

### DIFF
--- a/lib/Destiny/Common/Authentication/AbstractAuthHandler.php
+++ b/lib/Destiny/Common/Authentication/AbstractAuthHandler.php
@@ -55,7 +55,7 @@ abstract class AbstractAuthHandler extends Service implements AuthenticationHand
 
     public function getUserProfileUrl(string $username): string {
         // Assume the authenticator doesn't have profile pages if `$userProfileBaseUrl` is empty.
-        return !empty($this->userProfileBaseUrl) ? "$this->userProfileBaseUrl/$username" : null;
+        return !empty($this->userProfileBaseUrl) ? "$this->userProfileBaseUrl/$username" : '';
     }
 
 }


### PR DESCRIPTION
#190 had a bug where `AbstractAuthHandler.getUserProfileUrl()` sometimes returns `null` when it's defined to only return a `string`.