### PR TITLE
Fix config file issues

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -310,6 +310,7 @@ return [
 
     'iplookupservices' => [
         ['label' => 'iplocation.net', 'url' => 'https://www.iplocation.net/?query={IP_ADDRESS}'],
-        ['label' => 'greynoise.io','url' => 'https://viz.greynoise.io/query/?gnql=ip%3A{IP_ADDRESS}'],
+        ['label' => 'greynoise.io','url' => 'https://viz.greynoise.io/ip/{IP_ADDRESS}'],
+        ['label' => 'shodan.io','url' => 'https://www.shodan.io/host/{IP_ADDRESS}'],
     ]
 ];

--- a/config/config.php
+++ b/config/config.php
@@ -106,18 +106,6 @@ return [
         ]
     ],
 
-    'twitch_webhooks' => [
-        'client_id' => '',
-        'callback' => '',
-        'secret' => '',
-    ],
-
-    'twitch_api' => [
-        'client_id' => '',
-        'client_secret' => '',
-        'redirect_uri' => ''
-    ],
-
     'cookie' => [
         'domain' => '',
         'path' => '/',
@@ -185,6 +173,7 @@ return [
     'twitch' => [
         'id' => -1,
         'user' => '',
+        'webhooks_callback' => '',
     ],
 
     'discord' => [

--- a/lib/Destiny/Twitch/TwitchApiService.php
+++ b/lib/Destiny/Twitch/TwitchApiService.php
@@ -18,7 +18,7 @@ class TwitchApiService extends Service {
     private $tmiBase = 'https://tmi.twitch.tv';
 
     public function getApiCredentials(): array {
-        return Config::$a['twitch_api'];
+        return Config::$a['oauth_providers']['twitch'];
     }
 
     /**


### PR DESCRIPTION
`config.php` has four sets of API keys for Twitch: [here](https://github.com/destinygg/website/blob/4d656460fb6ca60d21af585c539ea5dd0261ae4e/config/config.php#L72-L76), [here](https://github.com/destinygg/website/blob/4d656460fb6ca60d21af585c539ea5dd0261ae4e/config/config.php#L97-L101), [here](https://github.com/destinygg/website/blob/4d656460fb6ca60d21af585c539ea5dd0261ae4e/config/config.php#L109-L113), and [here](https://github.com/destinygg/website/blob/4d656460fb6ca60d21af585c539ea5dd0261ae4e/config/config.php#L115-L119). Besides being redundant, this resulted in a bug in #183 where the client ID used to fetch an app access token required to subscribe to a Twitch webhook didn't match the client ID used for the actual subscription request.

```
**Error handling twitch hook cron task Error sending twitch webhook subscription request. {"error":"Unauthorized","status":401,"message":"Client ID and OAuth token do not match"}**
```

I don't think there's a good reason to have four sets of keys, so this PR "merges" three of the four into one. The only one that's untouched is `twitchbroadcaster`, which is used exclusively to generate access and refresh tokens for the broadcaster.

This PR also restores the original IP lookup services that were modified in #190. I had the impression some of them were no longer working when they were fine.

Here's what you have to change if you have an existing `config.local.php`:

1. Copy [this](https://github.com/destinygg/website/blob/4d656460fb6ca60d21af585c539ea5dd0261ae4e/config/config.php#L111) into [this](https://github.com/destinygg/website/blob/4d656460fb6ca60d21af585c539ea5dd0261ae4e/config/config.php#L185-L188) and rename it to `webhooks_callback`.
2. Delete [these](https://github.com/destinygg/website/blob/4d656460fb6ca60d21af585c539ea5dd0261ae4e/config/config.php#L109-L119).