### PR TITLE
Remove deprecated Twitch scope for broadcaster authentication

### DIFF
--- a/lib/Destiny/Twitch/TwitchBroadcastAuthHandler.php
+++ b/lib/Destiny/Twitch/TwitchBroadcastAuthHandler.php
@@ -10,7 +10,7 @@ class TwitchBroadcastAuthHandler extends TwitchAuthHandler {
 
     public $authProvider = AuthProvider::TWITCHBROADCAST;
 
-    public function getAuthorizationUrl($scope = ['openid', 'user:read:email', 'channel_subscriptions', 'channel_check_subscription', 'chat_login'], $claims = '{"userinfo":{"picture":null, "email":null, "email_verified":null, "preferred_username": null}}'): string {
+    public function getAuthorizationUrl($scope = ['openid', 'user:read:email', 'channel_subscriptions', 'channel_check_subscription'], $claims = '{"userinfo":{"picture":null, "email":null, "email_verified":null, "preferred_username": null}}'): string {
         return parent::getAuthorizationUrl($scope, $claims);
     }
 


### PR DESCRIPTION
When a broadcaster authenticates on `/admin/twitch`, access and refresh tokens for their account are acquired from Twitch and displayed on the page. These keys are meant to be used in destinygg/website2, a project that uses Twitch's PubSub system to check for new subscribers, as evidenced by the `channel_subscriptions` and `channel_check_subscription` scopes passed in the request.

Unfortunately, trying to authenticate gives you a status code 400 response.

```
{"status":400,"message":"Sorry, the scope you are requesting is currently unavailable. Please request new scopes documented at https://dev.twitch.tv/docs/authentication/#chat-and-pubsub."}
``` 

A little digging through Twitch's API docs [reveals](https://dev.twitch.tv/docs/authentication/#twitch-api-v5) that the one of the scopes passed in the request, `chat_login`, is deprecated and cannot be requested by new clients.

This PR simply removes the `chat_login` scope. It seems to be an unused relic from ages past.