### PR TITLE
Fix issue with accessing Twitch broadcaster's user page

### DIFF
--- a/lib/Destiny/Common/Authentication/AuthenticationService.php
+++ b/lib/Destiny/Common/Authentication/AuthenticationService.php
@@ -22,6 +22,7 @@ use Destiny\Reddit\RedditAuthHandler;
 use Destiny\StreamElements\StreamElementsAuthHandler;
 use Destiny\StreamLabs\StreamLabsAuthHandler;
 use Destiny\Twitch\TwitchAuthHandler;
+use Destiny\Twitch\TwitchBroadcastAuthHandler;
 use Destiny\Twitter\TwitterAuthHandler;
 
 /**
@@ -380,6 +381,9 @@ class AuthenticationService extends Service {
                 break;
             case AuthProvider::STREAMLABS:
                 $authHandler = new StreamLabsAuthHandler();
+                break;
+            case AuthProvider::TWITCHBROADCAST:
+                $authHandler = new TwitchBroadcastAuthHandler();
                 break;
             default:
                 throw new Exception('No authentication handler found.');


### PR DESCRIPTION
Since #190, accessing the user page of a user who authenticated via `/admin/twitch` (the broadcaster) is no longer possible. Trying to do so displays a cryptic message that reads `Application error`.

This ultimately happens because `AuthenticationService->getLoginAuthHandlerByType()` doesn't recognize `twitchbroadcaster` as a valid auth provider, so a `No authentication handler found.` exception is thrown when trying to linkify their username in the Authentication section of the user page.

This PR updates the function to correctly return the provider when requested, which fixes the problem.