### PR TITLE
Group linked bans together on user edit page

### DIFF
--- a/assets/web/css/style.scss
+++ b/assets/web/css/style.scss
@@ -2042,7 +2042,7 @@ form#nameForm {
     }
 
     td:nth-child(3) {
-      width: 160px;
+      width: 200px;
     }
 
     td:nth-child(4), td:nth-child(5) {

--- a/lib/Destiny/Chat/ChatBanService.php
+++ b/lib/Destiny/Chat/ChatBanService.php
@@ -228,7 +228,7 @@ class ChatBanService extends Service {
                     u.username AS banningusername,
                     b.targetuserid targetuserid,
                     u2.username AS targetusername,
-                    b.ipaddress,
+                    GROUP_CONCAT(b.ipaddress) as ipaddresses,
                     b.reason,
                     b.starttimestamp,
                     b.endtimestamp,
@@ -239,6 +239,7 @@ class ChatBanService extends Service {
                     INNER JOIN dfl_users AS u2 ON u2.userId = b.targetuserid
                   WHERE 
                     b.targetuserid = :userId
+                  GROUP BY b.reason, b.starttimestamp, b.endtimestamp
                   ORDER BY b.id DESC
                   LIMIT :amount
             ');

--- a/lib/Destiny/Chat/ChatBanService.php
+++ b/lib/Destiny/Chat/ChatBanService.php
@@ -122,6 +122,43 @@ class ChatBanService extends Service {
     }
 
     /**
+     * Updates all active bans for a user.
+     *
+     * IP bans may result in multiple active bans for a single user in the
+     * `bans` table (one for each IP address they ever connected with). They
+     * should always have the same `reason`, `starttimestamp`, and
+     * `endtimestamp` for proper enforcement. This function provides a
+     * convenient way of updating all of them at once.
+     *
+     * @throws DBException
+     */
+    public function updateActiveBansForUser(int $userId, string $reason, string $startTimestamp, string $endTimestamp = null) {
+        try {
+            $conn = Application::getDbConn();
+            $stmt = $conn->prepare('
+              UPDATE
+                bans
+              SET
+                reason = :reason,
+                starttimestamp = :startTimestamp,
+                endtimestamp = :endTimestamp
+              WHERE
+                targetuserid = :userId AND
+                (endtimestamp IS NULL OR endtimestamp >= NOW())
+            ');
+
+            $stmt->bindValue('reason', $reason, PDO::PARAM_STR);
+            $stmt->bindValue('startTimestamp', $startTimestamp, PDO::PARAM_STR);
+            $stmt->bindValue('endTimestamp', $endTimestamp, PDO::PARAM_STR);
+            $stmt->bindValue('userId', $userId, PDO::PARAM_INT);
+
+            $stmt->execute();
+        } catch (DBALException $e) {
+            throw new DBException("Error updating active user bans.", $e);
+        }
+    }
+
+    /**
      * @return array|false
      * @throws DBException
      */

--- a/lib/Destiny/Controllers/AdminUserController.php
+++ b/lib/Destiny/Controllers/AdminUserController.php
@@ -450,6 +450,8 @@ class AdminUserController {
         $authService = AuthenticationService::instance();
         $banId = $chatBanService->insertBan($ban);
         $authService->flagUserForUpdate($ban['targetuserid']);
+
+        Session::setSuccessBag('User has been banned!');
         return "redirect: /admin/user/$userId/ban/$banId/edit";
     }
 
@@ -548,6 +550,8 @@ class AdminUserController {
         }
         $chatBanService->updateBan($ban);
         $authService->flagUserForUpdate($ban ['targetuserid']);
+
+        Session::setSuccessBag('Ban updated!');
         return 'redirect: /admin/user/' . $params ['userId'] . '/ban/' . $params ['id'] . '/edit';
     }
 
@@ -572,6 +576,7 @@ class AdminUserController {
         if (isset($params['follow']) and substr($params['follow'], 0, 1) == '/')
             return 'redirect: ' . $params['follow'];
 
+        Session::setSuccessBag('Ban removed!');
         return 'redirect: /admin/user/' . $params ['userId'] . '/edit';
     }
 

--- a/lib/Destiny/Controllers/AdminUserController.php
+++ b/lib/Destiny/Controllers/AdminUserController.php
@@ -452,7 +452,7 @@ class AdminUserController {
         $authService->flagUserForUpdate($ban['targetuserid']);
 
         Session::setSuccessBag('User has been banned!');
-        return "redirect: /admin/user/$userId/ban/$banId/edit";
+        return "redirect: /admin/user/$userId/ban/edit";
     }
 
     /**
@@ -500,7 +500,7 @@ class AdminUserController {
     }
 
     /**
-     * @Route ("/admin/user/{userId}/ban/{id}/edit")
+     * @Route ("/admin/user/{userId}/ban/edit")
      * @Secure ({"MODERATOR"})
      * @HttpMethod ({"GET"})
      *
@@ -508,7 +508,6 @@ class AdminUserController {
      */
     public function editBan(array $params, ViewModel $model): string {
         FilterParams::required($params, 'userId');
-        FilterParams::required($params, 'id');
         $userService = UserService::instance();
         $chatBanService = ChatBanService::instance();
         $user = $userService->getUserById($params ['userId']);
@@ -517,12 +516,12 @@ class AdminUserController {
         }
         $model->title = 'Update Ban';
         $model->user = $user;
-        $model->ban = $chatBanService->getBanById($params ['id']);
+        $model->ban = $chatBanService->getUserActiveBan($params ['userId']);
         return 'admin/userban';
     }
 
     /**
-     * @Route ("/admin/user/{userId}/ban/{id}/update")
+     * @Route ("/admin/user/{userId}/ban/update")
      * @Secure ({"MODERATOR"})
      * @HttpMethod ({"POST"})
      * @Audit
@@ -531,9 +530,8 @@ class AdminUserController {
      */
     public function updateBan(array $params): string {
         FilterParams::required($params, 'userId');
-        FilterParams::required($params, 'id');
 
-        $redirect = "redirect: /admin/user/{$params['userId']}/ban/{$params['id']}/edit";
+        $redirect = "redirect: /admin/user/{$params['userId']}/ban/edit";
 
         try {
             FilterParams::required($params, 'reason');

--- a/lib/boot.app.php
+++ b/lib/boot.app.php
@@ -11,7 +11,7 @@ use Monolog\Handler\StreamHandler;
 use Monolog\Logger;
 use Monolog\Processor\PsrLogMessageProcessor;
 
-define('_APP_VERSION', '2.15.0'); // auto-generated: 1591323368375
+define('_APP_VERSION', '2.16.0'); // auto-generated: 1593731834832
 define('_BASEDIR', realpath(__DIR__ . '/../'));
 
 $loader = require _BASEDIR . '/vendor/autoload.php';

--- a/lib/boot.test.php
+++ b/lib/boot.test.php
@@ -8,7 +8,7 @@ use Monolog\Handler\StreamHandler;
 use Monolog\Logger;
 use Monolog\Processor\PsrLogMessageProcessor;
 
-define('_APP_VERSION', '2.15.0'); // auto-generated: 1591323368381
+define('_APP_VERSION', '2.16.0'); // auto-generated: 1593731834837
 define('_BASEDIR', realpath(__DIR__ . '/../'));
 
 $loader = require _BASEDIR . '/vendor/autoload.php';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dgg-website",
-  "version": "2.15.0",
+  "version": "2.16.0",
   "description": "Destiny.gg front-end",
   "main": "destiny",
   "scripts": {

--- a/views/admin/user.php
+++ b/views/admin/user.php
@@ -414,7 +414,7 @@ use Destiny\Commerce\SubscriptionStatus;
                                     </td>
                                     <td>
                                         <?php if ($ban['active']): ?>
-                                            <a class="btn btn-primary btn-sm mr-2" href="/admin/user/<?= $ban['targetuserid'] ?>/ban/<?= $ban['id'] ?>/edit"><i class="fas fa-fw fa-edit"></i></a><a id="delete-ban" class="btn btn-danger btn-sm" href="/admin/user/<?= $ban['targetuserid'] ?>/ban/remove"><i class="fas fa-fw fa-trash"></i></a>
+                                            <a class="btn btn-primary btn-sm mr-2" href="/admin/user/<?= $ban['targetuserid'] ?>/ban/edit"><i class="fas fa-fw fa-edit"></i></a><a id="delete-ban" class="btn btn-danger btn-sm" href="/admin/user/<?= $ban['targetuserid'] ?>/ban/remove"><i class="fas fa-fw fa-trash"></i></a>
                                         <?php endif; ?>
                                     </td>
                                 </tr>

--- a/views/admin/user.php
+++ b/views/admin/user.php
@@ -375,7 +375,7 @@ use Destiny\Commerce\SubscriptionStatus;
                             <tr>
                                 <td>Banned by</td>
                                 <td>Reason</td>
-                                <td>IP address</td>
+                                <td>IP addresses</td>
                                 <td>Date banned</td>
                                 <td>Expires on</td>
                                 <td></td>
@@ -393,16 +393,19 @@ use Destiny\Commerce\SubscriptionStatus;
                                     </td>
                                     <td><?= Tpl::out($ban['reason']) ?></td>
                                     <td>
-                                        <?php if (!empty($ban['ipaddress'])): ?>
-                                            <span class="mr-2"><?= Tpl::out($ban['ipaddress']) ?></span>
-                                            <div class="dropdown d-inline-block">
-                                                <button class="btn btn-sm btn-secondary dropdown-toggle" type="button" data-toggle="dropdown"><i class="fas fa-search"></i></button>
-                                                <div class="dropdown-menu">
-                                                    <?php foreach (Tpl::ipLookupLink($ban['ipaddress']) as $lookup): ?>
-                                                        <a class="dropdown-item" href="<?= Tpl::out($lookup['link']) ?>" target="_blank"><?= Tpl::out($lookup['label']) ?></a>
-                                                    <?php endforeach; ?>
+                                        <?php if (!empty($ban['ipaddresses'])): ?>
+                                            <?php foreach (explode(',', $ban['ipaddresses']) as $ipaddress): ?>
+                                                <?php if (empty($ipaddress)) { continue; } ?>
+                                                <span class="mr-1"><?= Tpl::out($ipaddress) ?></span>
+                                                <div class="dropdown d-inline-block">
+                                                    <button class="btn btn-sm btn-secondary dropdown-toggle" type="button" data-toggle="dropdown"><i class="fas fa-search"></i></button>
+                                                    <div class="dropdown-menu">
+                                                        <?php foreach (Tpl::ipLookupLink($ipaddress) as $lookup): ?>
+                                                            <a class="dropdown-item" href="<?= Tpl::out($lookup['link']) ?>" target="_blank"><?= Tpl::out($lookup['label']) ?></a>
+                                                        <?php endforeach; ?>
+                                                    </div>
                                                 </div>
-                                            </div>
+                                            <?php endforeach; ?>
                                         <?php endif; ?>
                                     </td>
                                     <td><?= Tpl::moment(Date::getDateTime($ban['starttimestamp']), Date::STRING_FORMAT) ?></td>

--- a/views/admin/userban.php
+++ b/views/admin/userban.php
@@ -19,7 +19,7 @@ use Destiny\Common\Utils\Tpl;
 
             <?php
             if(!empty($this->ban['id'])):
-                $href='/admin/user/'. Tpl::out($this->user['userId']) .'/ban/'. Tpl::out($this->ban['id']) .'/update';
+                $href='/admin/user/'. Tpl::out($this->user['userId']) .'/ban/update';
             else:
                 $href='/admin/user/'. Tpl::out($this->user['userId']) .'/ban';
             endif;

--- a/views/admin/userban.php
+++ b/views/admin/userban.php
@@ -46,7 +46,7 @@ use Destiny\Common\Utils\Tpl;
                         <label class="control-label" for="inputStarttimestamp">Start</label>
                         <div class="controls">
                             <input type="text" class="form-control" name="starttimestamp" id="inputStarttimestamp" value="<?=Tpl::out($this->ban['starttimestamp'])?>" placeholder="Y-m-d H:i:s">
-                            <span class="help-block">time specified in UCT</span>
+                            <span class="help-block">Time specified in UTC</span>
                         </div>
                     </div>
 
@@ -54,7 +54,7 @@ use Destiny\Common\Utils\Tpl;
                         <label class="control-label" for="inputEndtimestamp">End</label>
                         <div class="controls">
                             <input type="text" class="form-control" name="endtimestamp" id="inputEndtimestamp" value="<?=Tpl::out($this->ban['endtimestamp'])?>" placeholder="Y-m-d H:i:s">
-                            <span class="help-block">time specified in UCT</span>
+                            <span class="help-block">Time specified in UTC (leave blank for permanent)</span>
                         </div>
                     </div>
                 </div>

--- a/views/admin/userban.php
+++ b/views/admin/userban.php
@@ -70,6 +70,7 @@ use Destiny\Common\Utils\Tpl;
 
 </div>
 
+<?php include 'seg/alerts.php' ?>
 <?php include 'seg/foot.php' ?>
 <?php include 'seg/tracker.php' ?>
 <?=Tpl::manifestScript('runtime.js')?>


### PR DESCRIPTION
IP banning a user inserts multiple records into the `bans` table: one for each IP address we have on file for them with and one for the user themselves. These bans are considered "linked" because their `reason`, `starttimestamp`, and `endtimestamp` are identical. Linked bans are grouped together on the `/admin/bans` page. This PR groups them together in the recent bans table on `/admin/user/{id}/edit`, too.

This PR also modifies the ban update process to make inconsistencies between linked bans less likely and makes other, more minor improvements to updating, creating, or removing a ban.