### PR TITLE
Allow mods to bypass username-emote similarity checks

### DIFF
--- a/assets/web/css/style.scss
+++ b/assets/web/css/style.scss
@@ -2071,3 +2071,13 @@ form#nameForm {
     padding-bottom: 10px;
   }
 }
+
+#username-warning-modal {
+  .modal-content, .modal-header {
+    background-color: #282828;
+  }
+
+  button.close {
+    color: #DEDEDE;
+  }
+}

--- a/assets/web/js/admin.js
+++ b/assets/web/js/admin.js
@@ -414,3 +414,40 @@ $(function(){
     });
 
 });
+
+$(function() {
+    const $userDetailsForm = $('form#user-details');
+    const $usernameWarningModal = $('#username-warning-modal');
+    const $usernameInput = $('#inputUsername');
+
+    $userDetailsForm.submit(function(event) {
+        event.preventDefault();
+
+        $.get({
+            url: '/profile/username/similaremotes',
+            data: { 'username': $usernameInput.val() },
+            success: function(response) {
+                if ('error' in response) {
+                    $(document).alertDanger(response['error']['message'], {delay: 3000});
+                    return;
+                }
+
+                const emotes = response['data']['emotes'];
+                if (emotes.length) {
+                    // Display modal that warns the user if there are similar emotes.
+                    $usernameWarningModal.find('.modal-body p .username').text($usernameInput.val());
+                    $usernameWarningModal.find('.modal-body p .emotes').text(emotes.join(', '));
+                    $usernameWarningModal.modal('show');
+                } else {
+                    // Remove this submit handler and submit the form normally.
+                    $userDetailsForm.off('submit').submit();
+                }
+            }
+        });
+    });
+
+    $usernameWarningModal.find('button#update-anyway').click(function() {
+        $('input#skipEmoteCheck').val('true');
+        $userDetailsForm.off('submit').submit();
+    });
+});

--- a/lib/Destiny/Chat/EmoteService.php
+++ b/lib/Destiny/Chat/EmoteService.php
@@ -17,6 +17,7 @@ use PDO;
 class EmoteService extends Service {
 
     const EMOTES_DIR = _BASEDIR . '/static/emotes/';
+    const LUL_EMOTE_PREFIX = 'LUL';
 
     /**
      * @throws DBException

--- a/lib/Destiny/Common/Authentication/AuthenticationRedirectionFilter.php
+++ b/lib/Destiny/Common/Authentication/AuthenticationRedirectionFilter.php
@@ -83,6 +83,7 @@ class AuthenticationRedirectionFilter {
                 $username = $this->sanitizeUsername($username);
                 try {
                     $authService->validateUsername($username);
+                    $authService->checkUsernameForSimilarityToAllEmotes($username);
                     $userService->checkUsernameTaken($username);
                 } catch (Exception $e) {
                     $username = $this->buildTempUsername();

--- a/lib/Destiny/Common/Authentication/AuthenticationService.php
+++ b/lib/Destiny/Common/Authentication/AuthenticationService.php
@@ -115,6 +115,25 @@ class AuthenticationService extends Service {
     }
 
     /**
+     * Gets emote prefixes that are "too similar" to a username.
+     *
+     * @return array Contains all emote prefixes that are too similar to the supplied username.
+     */
+    public function getEmotesTooSimilarToUsername(string $username): array {
+        $conflictingEmotes = [];
+        foreach ($this->getEmotesForValidation() as $emote) {
+            $prefix = $emote['prefix'];
+            try {
+                $this->checkUsernameForSimilarityToEmote($username, $prefix);
+            } catch (Exception $e) {
+                $conflictingEmotes[] = $prefix;
+            }
+        }
+
+        return $conflictingEmotes;
+    }
+
+    /**
      * @throws Exception
      */
     public function validateEmail(string $email) {

--- a/lib/Destiny/Controllers/AdminUserController.php
+++ b/lib/Destiny/Controllers/AdminUserController.php
@@ -142,6 +142,7 @@ class AdminUserController {
 
         try {
             $authService->validateUsername($username);
+            $authService->checkUsernameForSimilarityToAllEmotes($username);
             $userService->checkUsernameTaken($username, $user['userId']);
         } catch (Exception $e) {
             Session::setErrorBag($e->getMessage());

--- a/lib/Destiny/Controllers/AdminUserController.php
+++ b/lib/Destiny/Controllers/AdminUserController.php
@@ -140,9 +140,13 @@ class AdminUserController {
         $features = (isset ($params['features'])) ? $params['features'] : [];
         $roles = (isset ($params['roles'])) ? $params['roles'] : [];
 
+        $skipEmoteCheck = !empty($params['skipEmoteCheck']);
+
         try {
             $authService->validateUsername($username);
-            $authService->checkUsernameForSimilarityToAllEmotes($username);
+            if (!$skipEmoteCheck) {
+                $authService->checkUsernameForSimilarityToAllEmotes($username);
+            }
             $userService->checkUsernameTaken($username, $user['userId']);
         } catch (Exception $e) {
             Session::setErrorBag($e->getMessage());

--- a/lib/Destiny/Controllers/DonateController.php
+++ b/lib/Destiny/Controllers/DonateController.php
@@ -78,7 +78,6 @@ class DonateController {
             }
             if (!Session::hasRole(UserRole::USER)) {
                 FilterParams::required($params, 'username');
-                $authService->validateUsername($params['username']);
             }
         } catch (Exception $e) {
             Session::setErrorBag($e->getMessage());

--- a/lib/Destiny/Controllers/ProfileController.php
+++ b/lib/Destiny/Controllers/ProfileController.php
@@ -140,6 +140,26 @@ class ProfileController {
     }
 
     /**
+     * @Route ("/profile/username/similaremotes")
+     * @HttpMethod ({"GET"})
+     * @Secure ({"USER"})
+     * @ResponseBody
+     */
+    public function emotesTooSimilarToUsername(array $params): array {
+        try {
+            FilterParams::declared($params, 'username');
+            $username = $params['username'];
+
+            $authService = AuthenticationService::instance();
+            $emotes = $authService->getEmotesTooSimilarToUsername($username);
+
+            return ['data' => ['emotes' => $emotes]];
+        } catch (Exception $e) {
+            return ['error' => ['message' => $e->getMessage()]];
+        }
+    }
+
+    /**
      * @Route ("/profile/update")
      * @HttpMethod ({"POST"})
      * @Secure ({"USER"})

--- a/lib/Destiny/Controllers/ProfileController.php
+++ b/lib/Destiny/Controllers/ProfileController.php
@@ -72,7 +72,11 @@ class ProfileController {
             FilterParams::declared($params, 'username');
             $username = (string) $params['username'];
             $userId = Session::getCredentials()->getUserId();
-            AuthenticationService::instance()->validateUsername($username);
+
+            $authService = AuthenticationService::instance();
+            $authService->validateUsername($username);
+            $authService->checkUsernameForSimilarityToAllEmotes($username);
+
             UserService::instance()->checkUsernameTaken($username, $userId);
         } catch (Exception $e) {
             return ['success' => false, 'error' => $e->getMessage()];
@@ -99,6 +103,7 @@ class ProfileController {
                 try {
                     $userService->checkUsernameTaken($username, $userId);
                     $authService->validateUsername($username);
+                    $authService->checkUsernameForSimilarityToAllEmotes($username);
                 } catch (Exception $e) {
                     Session::setErrorBag("Username taken... stop cheating. {$e->getMessage()}");
                     Log::warn("Failed to change username $userId. {$e->getMessage()}");

--- a/views/admin/user.php
+++ b/views/admin/user.php
@@ -29,7 +29,7 @@ use Destiny\Commerce\SubscriptionStatus;
         </h3>
         <div id="details-content" class="content content-dark clearfix collapse">
 
-            <form action="/admin/user/<?=Tpl::out($this->user['userId'])?>/edit" method="post">
+            <form id="user-details" action="/admin/user/<?=Tpl::out($this->user['userId'])?>/edit" method="post">
                 <input type="hidden" name="id" value="<?=Tpl::out($this->user['userId'])?>" />
 
                 <div class="ds-block">
@@ -186,6 +186,8 @@ use Destiny\Commerce\SubscriptionStatus;
                             </div>
                         </div>
                     </div>
+
+                    <input type="hidden" name="skipEmoteCheck" id="skipEmoteCheck">
 
                 </div>
 
@@ -503,6 +505,24 @@ use Destiny\Commerce\SubscriptionStatus;
     <?php endif ?>
 
 
+</div>
+
+<div class="modal" id="username-warning-modal" tabindex="-1" role="dialog">
+    <div class="modal-dialog modal-dialog-centered modal-lg" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title">Username warning</h5>
+                <button type="button" class="close" data-dismiss="modal">&times;</button>
+            </div>
+            <div class="modal-body">
+                <p>The username <span class="font-italic username"></span> is too similar to the following emotes: <span class="font-italic emotes"></span>.</p>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-primary" data-dismiss="modal">Cancel</button>
+                <button id="update-anyway" type="button" class="btn btn-secondary">Update Anyway</button>
+            </div>
+        </div>
+    </div>
 </div>
 
 <?php include 'seg/alerts.php' ?>


### PR DESCRIPTION
A username can't be "too similar" to an emote. The checks for emote similarity range from simply checking to see if the beginning of the username contains the emote's prefix, to calculating the Levenshtein distance between the two and checking if it exceeds some value.

This PR allows mods to override emote similarity violations and update the username anyway. If there's a violation, a modal will pop up listing the emotes that are too similar. The mod can then click "Update Anyway" to force the change.

![update username anyway](https://user-images.githubusercontent.com/20373896/86994578-97baae00-c15b-11ea-8525-a7ee41a20474.png)