### PR TITLE
Restore username validation for website donations

### DIFF
--- a/lib/Destiny/Controllers/DonateController.php
+++ b/lib/Destiny/Controllers/DonateController.php
@@ -78,6 +78,7 @@ class DonateController {
             }
             if (!Session::hasRole(UserRole::USER)) {
                 FilterParams::required($params, 'username');
+                $authService->validateUsername($params['username']);
             }
         } catch (Exception $e) {
             Session::setErrorBag($e->getMessage());


### PR DESCRIPTION
#201 removed the username validation check for donos. It turns out this check only applies to unregistered users who can type any username into the box, so it shouldn't have been removed. Checking for emote conflicts, however, is unnecessary.