### PR TITLE
Fix issue with searching for users by an IP address

### DIFF
--- a/lib/Destiny/Redis/RedisUtils.php
+++ b/lib/Destiny/Redis/RedisUtils.php
@@ -16,11 +16,16 @@ class RedisUtils {
     public static function callScript(string $scriptname, array $argument = []) {
         $redis = Application::instance()->getRedis();
         $dir = Config::$a['redis']['scriptdir'];
-        $hash = file_get_contents($dir . $scriptname . '.hash');
-        if ($hash) {
-            $ret = $redis->evalSha($hash, $argument);
-            if ($ret) return $ret;
+
+        $hashFilename = $dir . $scriptname . '.hash';
+        if (file_exists($hashFilename)) {
+            $hash = file_get_contents($hashFilename);
+            if ($hash) {
+                $ret = $redis->evalSha($hash, $argument);
+                if ($ret) return $ret;
+            }
         }
+
         $hash = $redis->script('load', file_get_contents($dir . $scriptname . '.lua'));
         if (!$hash) {
             throw new Exception('Unable to load script');

--- a/scripts/redis/check-ip-wildcard.lua
+++ b/scripts/redis/check-ip-wildcard.lua
@@ -6,9 +6,9 @@ local ip = ARGV[1]
 local foundusers = {}
 local keys = redis.call("KEYS", "CHAT:userips-*")
 for _, key in ipairs(keys) do
-    local rawData = redis.call('ZRANGE', key, 0, -1);
-    for idx = 1, #rawData, 2 do
-        if string.match(rawData[idx], ip) then
+    local userIps = redis.call('ZRANGE', key, 0, -1);
+    for _, userIp in ipairs(userIps) do
+        if string.match(userIp, ip) then
            table.insert(foundusers, key)
         end
     end


### PR DESCRIPTION
When searching for users by an IP address on `/admin/chat`, the `check-ip-wildcard` Redis script looks through every user's cached IPs for a match. Turns out the script was only ever checking the first and third cached IP because of a minor for loop bug.

It's possible Cene stepped by 2 because he thought `ZRANGE` returns elements with their scores, but it only does so when `WITHSCORES` is passed as an argument.

Remember to `rm scripts/redis/check-ip-wildcard.hash` after deployment so the script hash is regenerated!