### PR TITLE
Parse Bot-generated ban reasons in recent bans table

### DIFF
--- a/lib/Destiny/Chat/ChatBanService.php
+++ b/lib/Destiny/Chat/ChatBanService.php
@@ -261,7 +261,6 @@ class ChatBanService extends Service {
             $stmt = $conn->prepare('
                   SELECT
                     b.id,
-                    b.userid AS banninguserid,
                     u.username AS banningusername,
                     b.targetuserid targetuserid,
                     u2.username AS targetusername,

--- a/lib/Destiny/Chat/ChatBanService.php
+++ b/lib/Destiny/Chat/ChatBanService.php
@@ -283,7 +283,11 @@ class ChatBanService extends Service {
             $stmt->bindValue('userId', $userId, PDO::PARAM_INT);
             $stmt->bindValue('amount', $limit, PDO::PARAM_INT);
             $stmt->execute();
-            return $stmt->fetchAll();
+
+            $bans = $stmt->fetchAll();
+            $bans = array_map(array($this, 'parseBotBanReason'), $bans);
+
+            return $bans;
         } catch (DBALException $e) {
             throw new DBException("Error getting bans for user.", $e);
         }

--- a/lib/Destiny/Chat/ChatBanService.php
+++ b/lib/Destiny/Chat/ChatBanService.php
@@ -289,4 +289,32 @@ class ChatBanService extends Service {
         }
     }
 
+    /**
+     * Split up a Bot-generated `reason` into its respective fields.
+     *
+     * A ban by Bot always has a reason in the following format:
+     * `<targetusername> banned through bot by <banningusername>. Reason:
+     * <reason>`. This function modifies a ban to make `banningusername` the
+     * username of the actual banner, not Bot, and `reason` the actual reason,
+     * not the Bot-generated reason. Non-Bot-bans are returned unmodified.
+     * 
+     * @return array The modified ban.
+     */
+    private function parseBotBanReason(array $ban): array {
+        if ($ban['banningusername'] == 'Bot') {
+            $parsed = preg_split('/ banned through bot by |\. Reason: /', $ban['reason']);
+
+            // Assume the reason was in the expected format and parsed
+            // successfully if exactly three strings were returned.
+            if (count($parsed) == 3) {
+                // Ignore `targetusername` because it may be outdated. 
+                list($_, $ban['banningusername'], $ban['reason']) = $parsed;
+
+                // Toggle this value so we still know it's a Bot ban.
+                $ban['botban'] = true;
+            }
+        }
+
+        return $ban;
+    }
 }

--- a/views/admin/user.php
+++ b/views/admin/user.php
@@ -401,13 +401,7 @@ use Destiny\Commerce\SubscriptionStatus;
                         <tbody>
                             <?php foreach ($this->bans as $ban): ?>
                                 <tr class="<?= !$ban['active'] ? 'expired' : '' ?>">
-                                    <td>
-                                        <?php if (!empty($ban['banninguserid'])): ?>
-                                            <a href="/admin/user/<?= $ban['banninguserid'] ?>/edit"><?= Tpl::out($ban['banningusername']) ?></a>
-                                        <?php else: ?>
-                                            System
-                                        <?php endif; ?>
-                                    </td>
+                                    <td><?= Tpl::out($ban['banningusername']) ?></td>
                                     <td><?= Tpl::out($ban['reason']) ?></td>
                                     <td>
                                         <?php if (!empty($ban['ipaddresses'])): ?>

--- a/views/admin/user.php
+++ b/views/admin/user.php
@@ -401,7 +401,7 @@ use Destiny\Commerce\SubscriptionStatus;
                         <tbody>
                             <?php foreach ($this->bans as $ban): ?>
                                 <tr class="<?= !$ban['active'] ? 'expired' : '' ?>">
-                                    <td><?= Tpl::out($ban['banningusername']) ?></td>
+                                    <td><?= Tpl::out($ban['banningusername']) ?><?= !empty($ban['botban']) ? '<i title="This ban was issued via Bot. *Beep Boop*" class="ml-1 fas fa-robot"></i>' : '' ?></td>
                                     <td><?= Tpl::out($ban['reason']) ?></td>
                                     <td>
                                         <?php if (!empty($ban['ipaddresses'])): ?>


### PR DESCRIPTION
Most bans on the site are issued in chat with `!ban` and related commands. These commands are processed by Bot, who puts together a `BAN` message and sends it off to the chat backend. The `reason` field for Bot's bans is always in the format `<BannedUser> banned through bot by <BanningUser>. Reason: <Reason>`, and Bot is always the banning user.

This PR aims to tidy things up in the recent bans table by parsing Bot's ban reasons and putting each field where it belongs.

### Before
![parse bot bans before](https://user-images.githubusercontent.com/20373896/87868315-66a36000-c949-11ea-85a4-79fe43924971.png)

### After
![parse bot bans after](https://user-images.githubusercontent.com/20373896/87868319-6c994100-c949-11ea-8a2d-c9088c24845c.png)