### PR TITLE
Add banned column to user search table

### DIFF
--- a/assets/web/css/style.scss
+++ b/assets/web/css/style.scss
@@ -2081,3 +2081,7 @@ form#nameForm {
     color: #DEDEDE;
   }
 }
+
+#banned-icon {
+  color: #ff3636;
+}

--- a/assets/web/css/style.scss
+++ b/assets/web/css/style.scss
@@ -2072,6 +2072,28 @@ form#nameForm {
   }
 }
 
+#users-table {
+  thead tr {
+    @include media-breakpoint-down(lg) {
+      td.username {
+        width: 360px;
+      }
+
+      td.status {
+        width: 100px;
+      }
+
+      td.banned {
+        width: 100px;
+      }
+
+      td.created-on {
+        width: 300px;
+      }
+    }
+  }
+}
+
 #username-warning-modal {
   .modal-content, .modal-header {
     background-color: #282828;

--- a/lib/Destiny/Common/User/UserService.php
+++ b/lib/Destiny/Common/User/UserService.php
@@ -350,6 +350,28 @@ class UserService extends Service {
     }
 
     /**
+     * Search for users.
+     *
+     * @param array $params An array of parameters.
+     *     $params = [
+     *         'search' => (string) String to search for in usernames, emails, and auth details.
+     *         'feature' => (int) ID of the feature users must have.
+     *         'role' => (int) ID of the role users must have.
+     *         'sort' => (string) Which property to sort found users by. One of `id`, `username`, `status`, or `banned`.
+     *         'order' => (string) How to sort the users. `ASC` for ascending or `DESC` for descending.
+     *         'page' => (int) Which page of users to return.
+     *         'size' => (int) Users per page.
+     *     ]
+     *
+     * @return array $pagination An array of return values.
+     *     $pagination = [
+     *         'list' => (array) The found users.
+     *         'total' => (int) Total number of found users.
+     *         'totalpages' => (int) Number of pages of found users.
+     *         'page' => (int) Current page.
+     *         'limit' => (int) Users per page.
+     *     ]
+     *
      * @throws DBException
      */
     public function searchAll(array $params): array {

--- a/lib/Destiny/Common/User/UserService.php
+++ b/lib/Destiny/Common/User/UserService.php
@@ -355,86 +355,152 @@ class UserService extends Service {
     public function searchAll(array $params): array {
         try {
             $joins = [];
-            $clauses = [];
-            $orders = [];
-        if (!empty($params['search'])) {
-            $clauses[] = '(u.username LIKE :wildcard1 OR u.email LIKE :wildcard1 OR u.userId IN (SELECT a.userId FROM dfl_users_auth a WHERE a.authDetail LIKE :wildcard1 OR a.authEmail LIKE :wildcard1))';
-            $orders[] = '
-              CASE
-                WHEN u.username LIKE :wildcard2 THEN 0
-                WHEN u.username LIKE :wildcard3 THEN 1
-                WHEN u.username LIKE :wildcard4 THEN 2
-                WHEN u.username LIKE :wildcard4 THEN 4
-                WHEN u.username LIKE :wildcard4 THEN 5
-              ELSE 3
-              END
+            $wheres = [];
+            $groupBys = [];
+            $orderBys = [];
+
+            $query = '
+                SELECT
+                    SQL_CALC_FOUND_ROWS
+                    u.userId,
+                    u.username,
+                    u.email,
+                    u.userStatus,
+                    u.createdDate
+                FROM
+                    dfl_users AS u
             ';
-            }
+
+            // When filtering users by a feature.
             if (!empty($params['feature'])) {
-                $joins[] = ' INNER JOIN dfl_users_features f ON f.userId = u.userId AND f.featureId = :featureId ';
+                $joins[] = '
+                    INNER JOIN
+                        dfl_users_features f
+                    ON
+                        f.userId = u.userId AND f.featureId = :featureId
+                ';
             }
+
+            // When filtering users by a role.
             if (!empty($params['role'])) {
-                $joins[] = ' INNER JOIN dfl_users_roles r ON r.userId = u.userId AND r.roleId = :roleId  ';
+                $joins[] = '
+                    INNER JOIN
+                        dfl_users_roles r
+                    ON
+                        r.userId = u.userId AND r.roleId = :roleId
+                ';
             }
-            if (!empty($params['status'])) {
-                $clauses[] = ' u.userStatus = :userStatus ';
+
+            // Grouping by `userId` removes duplicate records that may show up
+            // when filtering by feature or role.
+            if (!empty($params['feature']) || !empty($params['role'])) {
+                $groupBys[] = 'u.userId';
             }
-            if (!empty($params['sort'])) {
-                $sort = $params['sort'];
-                $order = $params['order'] ?? 'DESC';
-                switch (strtolower($sort)) {
-                    case 'id' :
-                        $orders[] = " u.userId $order ";
-                        break;
-                    case 'username' :
-                        $orders[] = " u.username $order ";
-                        break;
-                    case 'status' :
-                        $orders[] = " u.userStatus $order ";
-                        break;
-                }
-            }
-            $q = 'SELECT SQL_CALC_FOUND_ROWS u.userId, u.username, u.email, u.userStatus, u.createdDate FROM dfl_users AS u ';
-            $q .= ' ' . join(PHP_EOL, $joins);
-            if (count($clauses) > 0) {
-                $q .= ' WHERE ' . join(' AND ', $clauses);
-            }
-            if (count($joins) > 0) {
-                $q .= ' GROUP BY u.userId ';
-            }
-            if (count($orders) > 0) {
-                $q .= ' ORDER BY ' . join(', ', $orders);
-            }
-            $q .= ' LIMIT :start, :limit ';
-            $conn = Application::getDbConn();
-            $stmt = $conn->prepare($q);
+
+            // When searching for a user by username or email (or auth
+            // username).
             if (!empty($params['search'])) {
-                $stmt->bindValue('wildcard1', '%' . $params['search'] . '%', PDO::PARAM_STR);
-                $stmt->bindValue('wildcard2', $params['search'] . ' %', PDO::PARAM_STR);
-                $stmt->bindValue('wildcard3', $params['search'] . '%', PDO::PARAM_STR);
-                $stmt->bindValue('wildcard4', '% %' . $params['search'] . '% %', PDO::PARAM_STR);
+                $wheres[] = '
+                    (
+                        u.username LIKE :containsMatch OR
+                        u.email LIKE :containsMatch OR
+                        u.userId IN (
+                            SELECT
+                                a.userId
+                            FROM
+                                dfl_users_auth a
+                            WHERE
+                                a.authDetail LIKE :containsMatch OR
+                                a.authEmail LIKE :containsMatch
+                        )
+                    )
+                ';
+
+                // When ordering results, take into account where the search
+                // string occurs in the username. For example, an exact match is
+                // sorted above matches that simply contain the word.
+                $orderBys[] = '
+                    CASE
+                        WHEN u.username LIKE :exactMatch THEN 0
+                        WHEN u.username LIKE :beginsMatch THEN 1
+                        WHEN u.username LIKE :containsMatch THEN 2
+                    ELSE 3
+                    END
+                ';
             }
+
+            // When filtering users by status.
+            if (!empty($params['status'])) {
+                $wheres[] = 'u.userStatus = :userStatus';
+            }
+
+            // Order by direction doesn't work with `bindValue()`, so we insert
+            // it directly into the query, but not before confirming that it's a
+            // whitelisted value to prevent SQL injection.
+            $directionWhitelist = ['ASC', 'DESC'];
+            $direction = !empty($params['order']) && in_array($params['order'], $directionWhitelist) ? $params['order'] : 'DESC';
+
+            $sort = $params['sort'] ?? 'id';
+            switch ($sort) {
+                case 'id':
+                    $orderBys[] = "u.userId $direction";
+                    break;
+                case 'username':
+                    $orderBys[] = "u.username $direction";
+                    break;
+                case 'status':
+                    $orderBys[] = "u.userStatus $direction";
+                    break;
+            }
+
+
+            // Combine clauses.
+            if (!empty($joins)) {
+                $query .= implode(' ', $joins);
+            }
+            if (!empty($wheres)) {
+                $query .= ' WHERE ' . implode(' AND ', $wheres);
+            }
+            if (!empty($groupBys)) {
+                $query .= ' GROUP BY ' . implode(', ', $groupBys);
+            }
+            if (!empty($orderBys)) {
+                $query .= ' ORDER BY ' . implode(', ', $orderBys);
+            }
+            $query .= ' LIMIT :start, :limit';
+
+
+            // Bind values and execute.
+            $conn = Application::getDbConn();
+            $stmt = $conn->prepare($query);
+
             if (!empty($params['feature'])) {
                 $stmt->bindValue('featureId', $params['feature'], PDO::PARAM_INT);
             }
             if (!empty($params['role'])) {
                 $stmt->bindValue('roleId', $params['role'], PDO::PARAM_INT);
             }
+            if (!empty($params['search'])) {
+                $stmt->bindValue('exactMatch', $params['search'], PDO::PARAM_STR);
+                $stmt->bindValue('beginsMatch', $params['search'] . '%', PDO::PARAM_STR);
+                $stmt->bindValue('containsMatch', '%' . $params['search'] . '%', PDO::PARAM_STR);
+            }
             if (!empty($params['status'])) {
                 $stmt->bindValue('userStatus', $params['status'], PDO::PARAM_STR);
             }
 
             $stmt->bindValue('start', ($params['page'] - 1) * $params['size'], PDO::PARAM_INT);
-            $stmt->bindValue('limit', (int) $params['size'], PDO::PARAM_INT);
+            $stmt->bindValue('limit', intval($params['size']), PDO::PARAM_INT);
             $stmt->execute();
 
             $pagination = [];
-            $pagination ['list'] = $stmt->fetchAll();
-            $pagination ['total'] = $conn->fetchColumn('SELECT FOUND_ROWS()');
-            $pagination ['totalpages'] = ceil($pagination ['total'] / $params['size']);
-            $pagination ['pages'] = 5;
-            $pagination ['page'] = $params['page'];
-            $pagination ['limit'] = $params['size'];
+            $pagination['list'] = $stmt->fetchAll();
+            $pagination['total'] = $conn->fetchColumn('SELECT FOUND_ROWS()');
+            $pagination['totalpages'] = ceil($pagination['total'] / $params['size']);
+            $pagination['pages'] = 5;
+            $pagination['page'] = $params['page'];
+            $pagination['limit'] = $params['size'];
+
             return $pagination;
         } catch (DBALException $e) {
             throw new DBException("Failed to search users.", $e);

--- a/lib/Destiny/Common/User/UserService.php
+++ b/lib/Destiny/Common/User/UserService.php
@@ -458,6 +458,9 @@ class UserService extends Service {
                 case 'status':
                     $orderBys[] = "u.userStatus $direction";
                     break;
+                case 'banned':
+                    $orderBys[] = "banned $direction";
+                    break;
             }
 
 

--- a/lib/Destiny/Common/User/UserService.php
+++ b/lib/Destiny/Common/User/UserService.php
@@ -507,7 +507,6 @@ class UserService extends Service {
             $pagination['list'] = $stmt->fetchAll();
             $pagination['total'] = $conn->fetchColumn('SELECT FOUND_ROWS()');
             $pagination['totalpages'] = ceil($pagination['total'] / $params['size']);
-            $pagination['pages'] = 5;
             $pagination['page'] = $params['page'];
             $pagination['limit'] = $params['size'];
 

--- a/views/admin/users.php
+++ b/views/admin/users.php
@@ -108,31 +108,33 @@ use Destiny\Common\Utils\Date;
 
                     </div>
 
-                    <table id="users-table" class="grid" data-sort="<?=Tpl::out($this->sort)?>" data-order="<?=Tpl::out($this->order)?>">
-                        <thead>
-                            <tr>
-                                <td class="selector"><i class="far fa-circle"></i></td>
-                                <td style="width: 300px;" data-sort="username">User</td>
-                                <td data-sort="status">Status</td>
-                                <td data-sort="id">Created on</td>
-                                <td data-sort="banned">Banned</td>
-                            </tr>
-                        </thead>
-                        <tbody>
-                        <?php foreach($this->users['list'] as $user): ?>
-                            <tr>
-                                <td data-id="<?=$user['userId']?>" class="selector"><i class="far fa-circle"></i></td>
-                                <td>
-                                    <a href="/admin/user/<?=$user['userId']?>/edit"><?=Tpl::out($user['username'])?></a>
-                                    <?php if(!empty($user['email'])): ?>(<?=Tpl::out($user['email'])?>)<?php endif; ?>
-                                </td>
-                                <td><?=$user['userStatus']?></td>
-                                <td><?=Tpl::moment(Date::getDateTime($user['createdDate']), Date::STRING_FORMAT)?></td>
-                                <td><?= $user['banned'] ? '<i id="banned-icon" class="fas fa-ban" title="This user is banned."></i>' : '' ?></td>
-                            </tr>
-                        <?php endforeach; ?>
-                        </tbody>
-                    </table>
+                    <div class="table-responsive">
+                        <table id="users-table" class="grid" data-sort="<?=Tpl::out($this->sort)?>" data-order="<?=Tpl::out($this->order)?>">
+                            <thead>
+                                <tr>
+                                    <td class="selector"><i class="far fa-circle"></i></td>
+                                    <td class="username" data-sort="username">User</td>
+                                    <td class="status text-center" data-sort="status">Status</td>
+                                    <td class="banned text-center" data-sort="banned">Banned</td>
+                                    <td class="created-on" data-sort="id">Created on</td>
+                                </tr>
+                            </thead>
+                            <tbody>
+                            <?php foreach($this->users['list'] as $user): ?>
+                                <tr>
+                                    <td data-id="<?=$user['userId']?>" class="selector"><i class="far fa-circle"></i></td>
+                                    <td>
+                                        <a href="/admin/user/<?=$user['userId']?>/edit"><?=Tpl::out($user['username'])?></a>
+                                        <?php if(!empty($user['email'])): ?>(<?=Tpl::out($user['email'])?>)<?php endif; ?>
+                                    </td>
+                                    <td class="text-center"><?=$user['userStatus']?></td>
+                                    <td class="text-center"><?= $user['banned'] ? '<i id="banned-icon" class="fas fa-ban" title="This user is banned."></i>' : '' ?></td>
+                                    <td><?=Tpl::moment(Date::getDateTime($user['createdDate']), Date::STRING_FORMAT)?></td>
+                                </tr>
+                            <?php endforeach; ?>
+                            </tbody>
+                        </table>
+                    </div>
 
                 </div>
             </div>

--- a/views/admin/users.php
+++ b/views/admin/users.php
@@ -115,6 +115,7 @@ use Destiny\Common\Utils\Date;
                                 <td style="width: 300px;" data-sort="username">User</td>
                                 <td data-sort="status">Status</td>
                                 <td data-sort="id">Created on</td>
+                                <td data-sort="banned">Banned</td>
                             </tr>
                         </thead>
                         <tbody>
@@ -127,6 +128,7 @@ use Destiny\Common\Utils\Date;
                                 </td>
                                 <td><?=$user['userStatus']?></td>
                                 <td><?=Tpl::moment(Date::getDateTime($user['createdDate']), Date::STRING_FORMAT)?></td>
+                                <td><?= $user['banned'] ? '<i id="banned-icon" class="fas fa-ban" title="This user is banned."></i>' : '' ?></td>
                             </tr>
                         <?php endforeach; ?>
                         </tbody>


### PR DESCRIPTION
* Adds a column to the user search table on `/admin/users` that tells you whether or not the user is banned.
* Updates the table's CSS to prevent columns from overlapping.
* Makes it a little easier to follow what happens in `searchAll()`.

![banned column in users search table](https://user-images.githubusercontent.com/20373896/88885404-50b95900-d1ed-11ea-8840-f29dbaa91afa.png)