### PR TITLE
Fix `/admin/user` slow load times

### DIFF
--- a/config/destiny.gg.sql
+++ b/config/destiny.gg.sql
@@ -13,7 +13,9 @@ CREATE TABLE `bans` (
   `reason` text NOT NULL,
   `starttimestamp` datetime NOT NULL,
   `endtimestamp` datetime DEFAULT NULL,
-  PRIMARY KEY (`id`)
+  PRIMARY KEY (`id`),
+  KEY `targetuserid` (`targetuserid`),
+  KEY `endtimestamp` (`endtimestamp`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE `dfl_features` (

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dgg-website",
-  "version": "2.14.1",
+  "version": "2.16.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dgg-website",
-  "version": "2.16.0",
+  "version": "2.16.1",
   "description": "Destiny.gg front-end",
   "main": "destiny",
   "scripts": {

--- a/scripts/db/upgrade-2.16.1-03-08-2020.sql
+++ b/scripts/db/upgrade-2.16.1-03-08-2020.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `bans` ADD INDEX IF NOT EXISTS `targetuserid` (`targetuserid`);
+ALTER TABLE `bans` ADD INDEX IF NOT EXISTS `endtimestamp` (`endtimestamp`);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -111,7 +111,8 @@ module.exports = {
     },
     resolve: {
         alias: { jquery: 'jquery/src/jquery' },
-        extensions: ['.js']
+        extensions: ['.js'],
+        symlinks: false,
     },
     context: __dirname,
     devtool: false


### PR DESCRIPTION
#207 modified the query used to populate the users table on `/admin/users` to also fetch each user's ban status. This query was painfully slow in production, where `dfl_users` and `bans` have far more rows than my teeny testing database.

This PR adds indexes to `bans.targetuserid` and `bans.endtimestamp`, which significantly improves the performance of the query.

After deploying, remember to run the database upgrade script, `scripts/db/upgrade-2.16.1-03-08-2020.sql`.