### PR TITLE
Install dgg-chat-gui from npm registry

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2768,8 +2768,9 @@
       "dev": true
     },
     "dgg-chat-gui": {
-      "version": "git://github.com/destinygg/chat-gui.git#9f07cab1c982801ac1c48517b9797cad32f5c6e8",
-      "from": "git://github.com/destinygg/chat-gui.git#9f07cab1c982801ac1c48517b9797cad32f5c6e8",
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/dgg-chat-gui/-/dgg-chat-gui-2.3.4.tgz",
+      "integrity": "sha512-8vt3mwaYM4kHfVJLpFPrqvJtQseqNN4Ics+d4HfwOWApTf3NRdBsTc/C2DhVuDcYei2MGWxR+5qLmApHmclUJQ==",
       "requires": {
         "bufferutil": "^4.0.0",
         "jquery": "^3.4.1",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@fortawesome/fontawesome-free": "^5.10.2",
     "bootstrap": "^4.3.1",
     "chart.js": "^2.8.0",
-    "dgg-chat-gui": "git://github.com/destinygg/chat-gui.git#9f07cab1c982801ac1c48517b9797cad32f5c6e8",
+    "dgg-chat-gui": "^2.3.4",
     "jquery": "^3.4.1",
     "jquery-validation": "^1.19.1",
     "moment": "^2.24.0",


### PR DESCRIPTION
Now that destinygg/chat-gui was [published to the npm public registry](https://www.npmjs.com/package/dgg-chat-gui), we can install it from the registry and specify compatible versions. This approach is superior because `package.json` no longer has to be modified every time chat-gui is updated.