### PR TITLE
Show ban appeal hint in user profile page and chat

### DIFF
--- a/assets/chat.js
+++ b/assets/chat.js
@@ -7,7 +7,8 @@ const chat = new Chat({
     url: `ws${location.protocol === 'https:' ? 's' : ''}://${location.host}/ws`,
     api: {base: `${location.protocol}//${location.host}`},
     cdn: {base: script.getAttribute('data-cdn')},
-    cacheKey: script.getAttribute('data-cache-key')
+    cacheKey: script.getAttribute('data-cache-key'),
+    banAppealUrl: script.getAttribute('data-ban-appeal-url')
 });
 
 chat.withGui(require('dgg-chat-gui/assets/views/embed.html'))

--- a/assets/streamchat.js
+++ b/assets/streamchat.js
@@ -7,7 +7,8 @@ const chat = new Chat({
     url: `ws${location.protocol === 'https:' ? 's' : ''}://${location.host}/ws`,
     api: {base: `${location.protocol}//${location.host}`},
     cdn: {base: script.getAttribute('data-cdn')},
-    cacheKey: script.getAttribute('data-cache-key')
+    cacheKey: script.getAttribute('data-cache-key'),
+    banAppealUrl: script.getAttribute('data-ban-appeal-url')
 });
 
 $('body,html').css('background', 'transparent')

--- a/assets/votechat.js
+++ b/assets/votechat.js
@@ -7,7 +7,8 @@ const chat = new Chat({
     url: `ws${location.protocol === 'https:' ? 's' : ''}://${location.host}/ws`,
     api: {base: `${location.protocol}//${location.host}`},
     cdn: {base: script.getAttribute('data-cdn')},
-    cacheKey: script.getAttribute('data-cache-key')
+    cacheKey: script.getAttribute('data-cache-key'),
+    banAppealUrl: script.getAttribute('data-ban-appeal-url')
 });
 
 $('body,html').css('background', 'transparent')

--- a/config/config.dgg.php
+++ b/config/config.dgg.php
@@ -13,6 +13,7 @@ return [
     'reddit'        => ['threads' => 'https://www.reddit.com/r/destiny/hot.json'],
     'blog'          => ['feed' => 'https://blog.destiny.gg/feed/json'],
     'android'       => ['app' => 'gg.destiny.app.chat'],
+    'banAppealUrl'  => 'https://www.destiny.gg/unban',
 
     'twitch' => [
         'id' => 18074328,

--- a/config/config.php
+++ b/config/config.php
@@ -35,6 +35,7 @@ return [
     'support_email' => '',
     'google-verification' => '',
     'calendar' => '',
+    'merch' => [],
 
     'privateKeys' => [
         'reddit' => '',

--- a/config/config.php
+++ b/config/config.php
@@ -32,6 +32,7 @@ return [
     'android' => ['app' => ''],
     'meta' => [],
     'links' => [],
+    'banAppealUrl' => '',
     'support_email' => '',
     'google-verification' => '',
     'calendar' => '',

--- a/lib/boot.app.php
+++ b/lib/boot.app.php
@@ -11,7 +11,7 @@ use Monolog\Handler\StreamHandler;
 use Monolog\Logger;
 use Monolog\Processor\PsrLogMessageProcessor;
 
-define('_APP_VERSION', '2.16.0'); // auto-generated: 1593731834832
+define('_APP_VERSION', '2.17.0'); // auto-generated: 1596914360858
 define('_BASEDIR', realpath(__DIR__ . '/../'));
 
 $loader = require _BASEDIR . '/vendor/autoload.php';

--- a/lib/boot.test.php
+++ b/lib/boot.test.php
@@ -8,7 +8,7 @@ use Monolog\Handler\StreamHandler;
 use Monolog\Logger;
 use Monolog\Processor\PsrLogMessageProcessor;
 
-define('_APP_VERSION', '2.16.0'); // auto-generated: 1593731834837
+define('_APP_VERSION', '2.17.0'); // auto-generated: 1596914360862
 define('_BASEDIR', realpath(__DIR__ . '/../'));
 
 $loader = require _BASEDIR . '/vendor/autoload.php';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dgg-website",
-  "version": "2.16.1",
+  "version": "2.17.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dgg-website",
-  "version": "2.16.1",
+  "version": "2.17.0",
   "description": "Destiny.gg front-end",
   "main": "destiny",
   "scripts": {

--- a/views/chat.php
+++ b/views/chat.php
@@ -17,7 +17,8 @@ use Destiny\Common\Config;
 <?=Tpl::manifestScript('chat.js', [
     'id' => 'chat-include',
     'data-cache-key' => $this->cacheKey,
-    'data-cdn' => Config::cdnv()
+    'data-cdn' => Config::cdnv(),
+    'data-ban-appeal-url' => Config::$a['banAppealUrl']
 ])?>
 <?php include 'seg/tracker.php' ?>
 </body>

--- a/views/profile/account.php
+++ b/views/profile/account.php
@@ -5,6 +5,7 @@ use Destiny\Common\Utils\Tpl;
 use Destiny\Common\Utils\Country;
 use Destiny\Common\Utils\Date;
 use Destiny\Commerce\SubscriptionStatus;
+use Destiny\Common\Config;
 ?>
 <!DOCTYPE html>
 <html lang="en">
@@ -48,11 +49,11 @@ use Destiny\Commerce\SubscriptionStatus;
                         </dl>
                         <hr/>
                         <p>
-                            Any non-permanent bans are removed when subscribing as well
-                            as any mutes (there are no permanent mutes, maximum 6 days long).<br/>
-                            This is not meant to be a cash grab, rather a tool for those who would
-                            not like to wait for a manual unban or for the ban to naturally expire
-                            and are willing to pay for it. Please email <a href="mailto:unbans@destiny.gg">unbans@destiny.gg</a> to appeal.<br />
+                            Any non-permanent bans are removed when subscribing as well as any mutes (there are no permanent mutes, maximum 6 days long).<br>
+                            This is not meant to be a cash grab, rather a tool for those who would not like to wait for a manual unban or for the ban to naturally expire and are willing to pay for it.<br>
+                            <?php if(!empty(Config::$a['banAppealUrl'])): ?>
+                                Please visit <a target="_blank" href="<?= Config::$a['banAppealUrl'] ?>"><?= Config::$a['banAppealUrl'] ?></a> to appeal your ban.
+                            <?php endif; ?>
                         </p>
                     </div>
                 </div>

--- a/views/streamchat.php
+++ b/views/streamchat.php
@@ -17,7 +17,8 @@ use Destiny\Common\Config;
 <?=Tpl::manifestScript('streamchat.js', [
     'id' => 'chat-include',
     'data-cache-key' => $this->cacheKey,
-    'data-cdn' => Config::cdnv()
+    'data-cdn' => Config::cdnv(),
+    'data-ban-appeal-url' => Config::$a['banAppealUrl']
 ])?>
 <?php include 'seg/tracker.php' ?>
 </body>

--- a/views/votechat.php
+++ b/views/votechat.php
@@ -17,7 +17,8 @@ use Destiny\Common\Config;
 <?=Tpl::manifestScript('votechat.js', [
     'id' => 'chat-include',
     'data-cache-key' => $this->cacheKey,
-    'data-cdn' => Config::cdnv()
+    'data-cdn' => Config::cdnv(),
+    'data-ban-appeal-url' => Config::$a['banAppealUrl']
 ])?>
 <?php include 'seg/tracker.php' ?>
 </body>


### PR DESCRIPTION
This PR adds a config option for `banAppealUrl`, a page where punished users should go when they're ready to beg for forgiveness. In addition to being displayed on a user's profile page when they have an active ban, the URL is also passed to the chat frontend, which displays it when the user tries to connect while banned. This only works if the website is built with dgg-chat-gui version 2.4.0 or newer.

![ban appeal url in profile](https://user-images.githubusercontent.com/20373896/89718645-15e5bc80-d975-11ea-854f-d7df5a3b4e96.png)

![ban appeal url in chat](https://user-images.githubusercontent.com/20373896/89718648-19794380-d975-11ea-9933-510778d3e147.png)