### PR TITLE
Fix parsing of Bot-generated ban reasons

### DIFF
--- a/lib/Destiny/Chat/BanReasonParseRule.php
+++ b/lib/Destiny/Chat/BanReasonParseRule.php
@@ -1,0 +1,19 @@
+<?php
+namespace Destiny\Chat;
+
+class BanReasonParseRule {
+    function __construct(string $regex, callable $transform) {
+        $this->regex = $regex;
+        $this->transform = $transform;
+    }
+
+    public function test($ban): array {
+        $matches = [];
+        preg_match($this->regex, $ban['reason'], $matches);
+        return $matches;
+    }
+
+    public function apply($ban, $matches): array {
+        return ($this->transform)($ban, $matches);
+    }
+}

--- a/lib/Destiny/Chat/BanReasonParser.php
+++ b/lib/Destiny/Chat/BanReasonParser.php
@@ -1,0 +1,33 @@
+<?php
+namespace Destiny\Chat;
+
+class BanReasonParser {
+    const BOT_USERNAME = 'Bot';
+
+    public $rules;    
+
+    function __construct(array $rules) {
+        $this->rules = $rules;
+    }
+
+    public function transformBan($ban): array {
+        // Non-Bot-issued bans don't have ban reasons that qualify for parsing.
+        if (!$this->isBotBan($ban)) {
+            return $ban;
+        }
+
+        foreach ($this->rules as $rule) {
+            $matches = $rule->test($ban);
+            if (!empty($matches)) {
+                $ban = $rule->apply($ban, $matches);
+                break;
+            }
+        }
+
+        return $ban;
+    }
+
+    public function isBotBan($ban): bool {
+        return $ban['banningusername'] === BanReasonParser::BOT_USERNAME;
+    }
+}

--- a/lib/Destiny/Chat/BanReasonParserFactory.php
+++ b/lib/Destiny/Chat/BanReasonParserFactory.php
@@ -1,0 +1,100 @@
+<?php
+namespace Destiny\Chat;
+
+use Destiny\Chat\BanReasonParser;
+use Destiny\Chat\BanReasonParseRule;
+
+class BanReasonParserFactory {
+    public static function create(): BanReasonParser {
+        $rules = [
+            new BanReasonParseRule(
+                '/^MEGA NUKED by (?P<banningusername>\w+)$/',
+                function($ban, $matches) {
+                    // If `banningusername` changes, toggle this value so we
+                    // still know it's a Bot ban.
+                    $ban['botban'] = true;
+                    $ban['banningusername'] = $matches['banningusername'];
+                    $ban['reason'] = 'Blasted by a MEGA NUKE.';
+                    return $ban;
+                }
+            ),
+            new BanReasonParseRule(
+                '/^(?P<targetusername>\w+)\n       BANNED for (?P<duration>.+) for using a recently MEGA NUKED phrase \((?P<meganukedphrase>.+)\)\.$/',
+                function($ban, $matches) {
+                    $ban['reason'] = 'Blasted by a MEGA NUKE for ' . $matches['duration'] . ' for typing `' . $matches['meganukedphrase'] . '`.';
+                    return $ban;
+                }
+            ),
+            new BanReasonParseRule(
+                '/^(?P<targetusername>\w+) banned through bot by (?P<banningusername>\w+)\. \n     Reason: (?P<reason>.+)$/',
+                function($ban, $matches) {
+                    $ban['botban'] = true;
+                    $ban['banningusername'] = $matches['banningusername'];
+                    $ban['reason'] = $matches['reason'];
+                    return $ban;
+                }
+            ),
+            new BanReasonParseRule(
+                '/^(?P<targetusername>\w+) banned through bot by (?P<banningusername>\w+)\. \n    $/',
+                function($ban, $matches) {
+                    $ban['botban'] = true;
+                    $ban['banningusername'] = $matches['banningusername'];
+                    $ban['reason'] = 'No reason provided.';
+                    return $ban;
+                }
+            ),
+            new BanReasonParseRule(
+                '/^(?P<targetusername>\w+) banned for using banned phrase\((?P<bannedphrase>.+)\)\. Length: (?P<banlength>.+)\.$/',
+                function($ban, $matches) {
+                    $ban['reason'] = 'Banned for ' . $matches['banlength'] . ' for using banned phrase `' . $matches['bannedphrase'] . '`.';
+                    return $ban;
+                }
+            ),
+            new BanReasonParseRule(
+                '/^(?P<targetusername>\w+) banned for using banned phrase\. Length: (?P<banlength>.+)\.$/',
+                function($ban, $matches) {
+                    $ban['reason'] = 'Banned for ' . $matches['banlength'] . ' for using banned phrase.';
+                    return $ban;
+                }
+            ),
+            new BanReasonParseRule(
+                '/^(?P<targetusername>\w+) banned through bot by a VOTE BAN started by (?P<banningusername>\w+)\. Reason: (?P<reason>.+) Yes votes: (?P<yesvotes>\d+) No Votes: (?P<novotes>\d+)$/',
+                function($ban, $matches) {
+                    $ban['botban'] = true;
+                    $ban['banningusername'] = $matches['banningusername'];
+                    $ban['reason'] = 'Banned via VOTE BAN with ' . $matches['yesvotes'] . ' YES votes and ' . $matches['novotes'] . ' NO votes. Reason: ' . $matches['reason'];
+                    return $ban;
+                }
+            ),
+            new BanReasonParseRule(
+                '/^(?P<targetusername>\w+) banned through bot by a VOTE BAN started by (?P<banningusername>\w+)\.  Yes votes: (?P<yesvotes>\d+) No Votes: (?P<novotes>\d+)$/',
+                function($ban, $matches) {
+                    $ban['botban'] = true;
+                    $ban['banningusername'] = $matches['banningusername'];
+                    $ban['reason'] = 'Banned via VOTE BAN with ' . $matches['yesvotes'] . ' YES votes and ' . $matches['novotes'] . ' NO votes.';
+                    return $ban;
+                }
+            ),
+            new BanReasonParseRule(
+                '/^(?P<targetusername>\w+) banned through bot by a VOTE BAN started by (?P<banningusername>\w+)\.$/',
+                function($ban, $matches) {
+                    $ban['botban'] = true;
+                    $ban['banningusername'] = $matches['banningusername'];
+                    $ban['reason'] = 'Banned via VOTE BAN.';
+                    return $ban;
+                }
+            ),
+            new BanReasonParseRule(
+                '/^(?P<targetusername>\w+) banned through bot by GULAG battle started by (?P<banningusername>\w+)\. Votes: (?P<votes>\d+)$/',
+                function($ban, $matches) {
+                    $ban['botban'] = true;
+                    $ban['banningusername'] = $matches['banningusername'];
+                    $ban['reason'] = 'Bested in the GULAG where they received only ' . $matches['votes'] . ' votes.';
+                    return $ban;
+                }
+            )
+        ];
+
+        return new BanReasonParser($rules);
+    }
+}

--- a/lib/Destiny/Chat/ChatBanService.php
+++ b/lib/Destiny/Chat/ChatBanService.php
@@ -1,6 +1,7 @@
 <?php
 namespace Destiny\Chat;
 
+use Destiny\Chat\BanReasonParserFactory;
 use Destiny\Common\Application;
 use Destiny\Common\DBException;
 use Destiny\Common\Service;
@@ -284,40 +285,13 @@ class ChatBanService extends Service {
             $stmt->execute();
 
             $bans = $stmt->fetchAll();
-            $bans = array_map(array($this, 'parseBotBanReason'), $bans);
+
+            $parser = BanReasonParserFactory::create();
+            $bans = array_map(function($b) use ($parser) { return $parser->transformBan($b); }, $bans);
 
             return $bans;
         } catch (DBALException $e) {
             throw new DBException("Error getting bans for user.", $e);
         }
-    }
-
-    /**
-     * Split up a Bot-generated `reason` into its respective fields.
-     *
-     * A ban by Bot always has a reason in the following format:
-     * `<targetusername> banned through bot by <banningusername>. Reason:
-     * <reason>`. This function modifies a ban to make `banningusername` the
-     * username of the actual banner, not Bot, and `reason` the actual reason,
-     * not the Bot-generated reason. Non-Bot-bans are returned unmodified.
-     * 
-     * @return array The modified ban.
-     */
-    private function parseBotBanReason(array $ban): array {
-        if ($ban['banningusername'] == 'Bot') {
-            $parsed = preg_split('/ banned through bot by |\. Reason: /', $ban['reason']);
-
-            // Assume the reason was in the expected format and parsed
-            // successfully if exactly three strings were returned.
-            if (count($parsed) == 3) {
-                // Ignore `targetusername` because it may be outdated. 
-                list($_, $ban['banningusername'], $ban['reason']) = $parsed;
-
-                // Toggle this value so we still know it's a Bot ban.
-                $ban['botban'] = true;
-            }
-        }
-
-        return $ban;
     }
 }

--- a/lib/boot.app.php
+++ b/lib/boot.app.php
@@ -11,7 +11,7 @@ use Monolog\Handler\StreamHandler;
 use Monolog\Logger;
 use Monolog\Processor\PsrLogMessageProcessor;
 
-define('_APP_VERSION', '2.17.0'); // auto-generated: 1596914360858
+define('_APP_VERSION', '2.17.1'); // auto-generated: 1598056019939
 define('_BASEDIR', realpath(__DIR__ . '/../'));
 
 $loader = require _BASEDIR . '/vendor/autoload.php';

--- a/lib/boot.test.php
+++ b/lib/boot.test.php
@@ -8,7 +8,7 @@ use Monolog\Handler\StreamHandler;
 use Monolog\Logger;
 use Monolog\Processor\PsrLogMessageProcessor;
 
-define('_APP_VERSION', '2.17.0'); // auto-generated: 1596914360862
+define('_APP_VERSION', '2.17.1'); // auto-generated: 1598056019945
 define('_BASEDIR', realpath(__DIR__ . '/../'));
 
 $loader = require _BASEDIR . '/vendor/autoload.php';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dgg-website",
-  "version": "2.17.0",
+  "version": "2.17.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dgg-website",
-  "version": "2.17.0",
+  "version": "2.17.1",
   "description": "Destiny.gg front-end",
   "main": "destiny",
   "scripts": {


### PR DESCRIPTION
#205 *tried* to introduce a feature where Bot's ban reasons were parsed and important values contained within were moved to their respective fields to tidy things up. (Emphasis on *tried*.)

Firstly, the regex used to capture relevant fields within the ban reason was wrong. During Bot's development, some extra whitespace characters must have found their way in by mistake, which threw everything off.

Rather than looking like this

```
 aboycalledsue banned through bot by Destiny. Reason: Horrible taste in music.
```

they actually look like this

```
 aboycalledsue banned through bot by Destiny. \n     Reason: Horrible taste in music.
```

Note the newline and the extra spaces. Spotting the difference is tough when looking at a user's recent bans on `/admin/user`.

Secondly, the PR only attacked bans issued with the `!ban` command where a reason was supplied. There are also vote bans, gulag bans, banned phrase bans, and meganukes. Some ban types have reasons that change depending on the arguments passed to the command. Additionally, the exact wording can vary depending on which version of the Bot was in use at the time.

This PR addresses the above issues and makes everything work as it should.