### PR TITLE
Fix searching for usernames with underscores

### DIFF
--- a/lib/Destiny/Common/User/UserService.php
+++ b/lib/Destiny/Common/User/UserService.php
@@ -513,9 +513,12 @@ class UserService extends Service {
                 $stmt->bindValue('roleId', $params['role'], PDO::PARAM_INT);
             }
             if (!empty($params['search'])) {
-                $stmt->bindValue('exactMatch', $params['search'], PDO::PARAM_STR);
-                $stmt->bindValue('beginsMatch', $params['search'] . '%', PDO::PARAM_STR);
-                $stmt->bindValue('containsMatch', '%' . $params['search'] . '%', PDO::PARAM_STR);
+                // Treat all underscores as literal underscores.
+                $modifiedSearch = str_replace('_', '\_', $params['search']);
+
+                $stmt->bindValue('exactMatch', $modifiedSearch, PDO::PARAM_STR);
+                $stmt->bindValue('beginsMatch', $modifiedSearch . '%', PDO::PARAM_STR);
+                $stmt->bindValue('containsMatch', '%' . $modifiedSearch . '%', PDO::PARAM_STR);
             }
             if (!empty($params['status'])) {
                 $stmt->bindValue('userStatus', $params['status'], PDO::PARAM_STR);

--- a/lib/Destiny/Common/User/UserService.php
+++ b/lib/Destiny/Common/User/UserService.php
@@ -513,8 +513,9 @@ class UserService extends Service {
                 $stmt->bindValue('roleId', $params['role'], PDO::PARAM_INT);
             }
             if (!empty($params['search'])) {
-                // Treat all underscores as literal underscores.
-                $modifiedSearch = str_replace('_', '\_', $params['search']);
+                // Treat all underscores as literal underscores and asterisks as
+                // multi-character wildcards.
+                $modifiedSearch = str_replace(['_', '*'], ['\_', '%'], $params['search']);
 
                 $stmt->bindValue('exactMatch', $modifiedSearch, PDO::PARAM_STR);
                 $stmt->bindValue('beginsMatch', $modifiedSearch . '%', PDO::PARAM_STR);

--- a/lib/boot.app.php
+++ b/lib/boot.app.php
@@ -11,7 +11,7 @@ use Monolog\Handler\StreamHandler;
 use Monolog\Logger;
 use Monolog\Processor\PsrLogMessageProcessor;
 
-define('_APP_VERSION', '2.17.1'); // auto-generated: 1598056019939
+define('_APP_VERSION', '2.17.2'); // auto-generated: 1598331352123
 define('_BASEDIR', realpath(__DIR__ . '/../'));
 
 $loader = require _BASEDIR . '/vendor/autoload.php';

--- a/lib/boot.test.php
+++ b/lib/boot.test.php
@@ -8,7 +8,7 @@ use Monolog\Handler\StreamHandler;
 use Monolog\Logger;
 use Monolog\Processor\PsrLogMessageProcessor;
 
-define('_APP_VERSION', '2.17.1'); // auto-generated: 1598056019945
+define('_APP_VERSION', '2.17.2'); // auto-generated: 1598331352128
 define('_BASEDIR', realpath(__DIR__ . '/../'));
 
 $loader = require _BASEDIR . '/vendor/autoload.php';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dgg-website",
-  "version": "2.17.1",
+  "version": "2.17.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dgg-website",
-  "version": "2.17.1",
+  "version": "2.17.2",
   "description": "Destiny.gg front-end",
   "main": "destiny",
   "scripts": {


### PR DESCRIPTION
Searching for a username that contains an underscore inadvertently triggers a wildcard search. This PR fixes the issue.