### PR TITLE
Add support for `SameSite` cookie parameter

### DIFF
--- a/config/config.dgg.php
+++ b/config/config.dgg.php
@@ -29,6 +29,12 @@ return [
         'dgg_user' => 10
     ],
 
+    'cookie' => [
+        'domain' => 'www.destiny.gg',
+        'secure' => true,
+        'samesite' => 'none'
+    ],
+
     'meta' => [
         'shortName'      => 'Destiny.gg',
         'title'          => 'Destiny - Steven Bonnell II',

--- a/config/config.php
+++ b/config/config.php
@@ -113,6 +113,7 @@ return [
         'path' => '/',
         'secure' => false,
         'httponly' => true,
+        'samesite' => 'lax'
     ],
 
     'db' => [

--- a/lib/Destiny/Common/Session/Cookie.php
+++ b/lib/Destiny/Common/Session/Cookie.php
@@ -56,14 +56,34 @@ class Cookie {
 
     public function setValue($value, $expiry) {
         $_COOKIE[$this->name] = $value;
-        setcookie($this->name, $value, $expiry, $this->getPath(), $this->getDomain(), $this->getSecure(), $this->getHttpOnly());
+        setcookie(
+            $this->name,
+            $value,
+            [
+                'expires' => $expiry,
+                'path' => $this->getPath(),
+                'domain' => $this->getDomain(),
+                'secure' => $this->getSecure(),
+                'httponly' => $this->getHttpOnly()
+            ]
+        );
     }
 
     public function clearCookie() {
         if (isset ($_COOKIE[$this->name])) {
             unset ($_COOKIE[$this->name]);
         }
-        setcookie($this->name, '', time() - 3600, $this->getPath(), $this->getDomain(), $this->getSecure(), $this->getHttpOnly());
+        setcookie(
+            $this->name,
+            '',
+            [
+                'expires' => time() - 3600,
+                'path' => $this->getPath(),
+                'domain' => $this->getDomain(),
+                'secure' => $this->getSecure(),
+                'httponly' => $this->getHttpOnly()
+            ]
+        );
     }
 
 }

--- a/lib/Destiny/Common/Session/Cookie.php
+++ b/lib/Destiny/Common/Session/Cookie.php
@@ -11,6 +11,7 @@ class Cookie {
     public $domain = '';
     public $secure = false;
     public $httponly = true;
+    public $samesite = 'lax';
 
     public function __construct($name, array $params = null) {
         $this->setName($name);
@@ -47,6 +48,10 @@ class Cookie {
         return $this->httponly;
     }
 
+    public function getSameSite(): string {
+        return $this->samesite;
+    }
+
     public function getValue() {
         if (isset ($_COOKIE[$this->name])) {
             return $_COOKIE[$this->name];
@@ -64,7 +69,8 @@ class Cookie {
                 'path' => $this->getPath(),
                 'domain' => $this->getDomain(),
                 'secure' => $this->getSecure(),
-                'httponly' => $this->getHttpOnly()
+                'httponly' => $this->getHttpOnly(),
+                'samesite' => $this->getSameSite()
             ]
         );
     }
@@ -81,7 +87,8 @@ class Cookie {
                 'path' => $this->getPath(),
                 'domain' => $this->getDomain(),
                 'secure' => $this->getSecure(),
-                'httponly' => $this->getHttpOnly()
+                'httponly' => $this->getHttpOnly(),
+                'samesite' => $this->getSameSite()
             ]
         );
     }

--- a/lib/Destiny/Common/Session/SessionInstance.php
+++ b/lib/Destiny/Common/Session/SessionInstance.php
@@ -45,7 +45,8 @@ class SessionInstance {
             'path' => $sessionCookie->getPath(),
             'domain' => $sessionCookie->getDomain(),
             'secure' => $sessionCookie->getSecure(),
-            'httponly' => $sessionCookie->getHttpOnly()
+            'httponly' => $sessionCookie->getHttpOnly(),
+            'samesite' => $sessionCookie->getSameSite()
         ]);
         session_name($sessionCookie->getName());
     }

--- a/lib/Destiny/Common/Session/SessionInstance.php
+++ b/lib/Destiny/Common/Session/SessionInstance.php
@@ -40,13 +40,13 @@ class SessionInstance {
     }
 
     public function setupCookie(Cookie $sessionCookie) {
-        session_set_cookie_params(
-            $sessionCookie->getLife(),
-            $sessionCookie->getPath(),
-            $sessionCookie->getDomain(),
-            $sessionCookie->getSecure(),
-            $sessionCookie->getHttpOnly()
-        );
+        session_set_cookie_params([
+            'lifetime' => $sessionCookie->getLife(),
+            'path' => $sessionCookie->getPath(),
+            'domain' => $sessionCookie->getDomain(),
+            'secure' => $sessionCookie->getSecure(),
+            'httponly' => $sessionCookie->getHttpOnly()
+        ]);
         session_name($sessionCookie->getName());
     }
 

--- a/lib/boot.app.php
+++ b/lib/boot.app.php
@@ -11,7 +11,7 @@ use Monolog\Handler\StreamHandler;
 use Monolog\Logger;
 use Monolog\Processor\PsrLogMessageProcessor;
 
-define('_APP_VERSION', '2.17.2'); // auto-generated: 1598331352123
+define('_APP_VERSION', '2.18.0'); // auto-generated: 1599342531655
 define('_BASEDIR', realpath(__DIR__ . '/../'));
 
 $loader = require _BASEDIR . '/vendor/autoload.php';

--- a/lib/boot.test.php
+++ b/lib/boot.test.php
@@ -8,7 +8,7 @@ use Monolog\Handler\StreamHandler;
 use Monolog\Logger;
 use Monolog\Processor\PsrLogMessageProcessor;
 
-define('_APP_VERSION', '2.17.2'); // auto-generated: 1598331352128
+define('_APP_VERSION', '2.18.0'); // auto-generated: 1599342531662
 define('_BASEDIR', realpath(__DIR__ . '/../'));
 
 $loader = require _BASEDIR . '/vendor/autoload.php';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dgg-website",
-  "version": "2.17.2",
+  "version": "2.18.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dgg-website",
-  "version": "2.17.2",
+  "version": "2.18.0",
   "description": "Destiny.gg front-end",
   "main": "destiny",
   "scripts": {


### PR DESCRIPTION
[Chrome](https://blog.chromium.org/2020/02/samesite-cookie-changes-in-february.html) and [Firefox](https://hacks.mozilla.org/2020/08/changes-to-samesite-cookie-behavior/) recently made a change that affects how cookies are handled in third-party contexts.

1. If a cookie doesn't have an explicit `SameSite`, it's set to `SameSite=Lax` by default.
2. If `SameSite=None` for a cookie, the `Secure` attribute must be set, too.

This PR updates the `Cookie` class to support `SameSite` as a parameter, which is supplied via the `cookie` array in `config.php`. I also updated the Dgg-specific config to allow cross-site cookie delivery.