### PR TITLE
Cache the IP address new users sign up with

### DIFF
--- a/lib/Destiny/Chat/ChatRedisService.php
+++ b/lib/Destiny/Chat/ChatRedisService.php
@@ -72,6 +72,13 @@ class ChatRedisService extends Service {
     }
 
     /**
+     * @throws Exception
+     */
+    public function cacheIPForUser(int $userId, string $ipAddress) {
+        $keys = RedisUtils::callScript('cache-ip', ["CHAT:userips-$userId", $ipAddress], 1);
+    }
+
+    /**
      * @return array $ipaddresses The addresses found
      */
     public function getIPByUserId(int $userid): array {

--- a/lib/Destiny/Controllers/LoginController.php
+++ b/lib/Destiny/Controllers/LoginController.php
@@ -85,7 +85,7 @@ class LoginController {
             $authService = AuthenticationService::instance();
             $authHandler = $authService->getLoginAuthHandlerByType($type);
             $response = $authHandler->exchangeCode($params);
-            $redirectFilter = new AuthenticationRedirectionFilter($response);
+            $redirectFilter = new AuthenticationRedirectionFilter($response, $request);
             return $redirectFilter->execute();
         } catch (Exception $e) {
             Session::setErrorBag($e->getMessage());

--- a/lib/Destiny/Redis/RedisUtils.php
+++ b/lib/Destiny/Redis/RedisUtils.php
@@ -13,7 +13,7 @@ class RedisUtils {
      * @return mixed
      * @throws Exception
      */
-    public static function callScript(string $scriptname, array $argument = []) {
+    public static function callScript(string $scriptname, array $arguments = [], $numKeys = 0) {
         $redis = Application::instance()->getRedis();
         $dir = Config::$a['redis']['scriptdir'];
 
@@ -21,7 +21,7 @@ class RedisUtils {
         if (file_exists($hashFilename)) {
             $hash = file_get_contents($hashFilename);
             if ($hash) {
-                $ret = $redis->evalSha($hash, $argument);
+                $ret = $redis->evalSha($hash, $arguments, $numKeys);
                 if ($ret) return $ret;
             }
         }
@@ -33,7 +33,7 @@ class RedisUtils {
         if (!file_put_contents($dir . $scriptname . '.hash', $hash)) {
             throw new Exception('Unable to save hash');
         }
-        return $redis->evalSha($hash, $argument);
+        return $redis->evalSha($hash, $arguments, $numKeys);
     }
 
 }

--- a/lib/boot.app.php
+++ b/lib/boot.app.php
@@ -11,7 +11,7 @@ use Monolog\Handler\StreamHandler;
 use Monolog\Logger;
 use Monolog\Processor\PsrLogMessageProcessor;
 
-define('_APP_VERSION', '2.18.0'); // auto-generated: 1599342531655
+define('_APP_VERSION', '2.19.0'); // auto-generated: 1599535062861
 define('_BASEDIR', realpath(__DIR__ . '/../'));
 
 $loader = require _BASEDIR . '/vendor/autoload.php';

--- a/lib/boot.test.php
+++ b/lib/boot.test.php
@@ -8,7 +8,7 @@ use Monolog\Handler\StreamHandler;
 use Monolog\Logger;
 use Monolog\Processor\PsrLogMessageProcessor;
 
-define('_APP_VERSION', '2.18.0'); // auto-generated: 1599342531662
+define('_APP_VERSION', '2.19.0'); // auto-generated: 1599535062867
 define('_BASEDIR', realpath(__DIR__ . '/../'));
 
 $loader = require _BASEDIR . '/vendor/autoload.php';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dgg-website",
-  "version": "2.18.0",
+  "version": "2.19.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dgg-website",
-  "version": "2.18.0",
+  "version": "2.19.0",
   "description": "Destiny.gg front-end",
   "main": "destiny",
   "scripts": {

--- a/public/index.php
+++ b/public/index.php
@@ -48,7 +48,7 @@ try {
         'uri' => $_SERVER['REQUEST_URI'],
         'method' => $_SERVER['REQUEST_METHOD'],
         'headers' => Http::extractHeaders($_SERVER),
-        'ipAddress' => Http::extractIpAddress($_SERVER),
+        'address' => Http::extractIpAddress($_SERVER),
         'get' => $_GET,
         'post' => $_POST
     ]));

--- a/scripts/redis/cache-ip.lua
+++ b/scripts/redis/cache-ip.lua
@@ -1,0 +1,34 @@
+local key, value, maxlength = KEYS[1], ARGV[1], 3
+
+local count = redis.call("ZCOUNT", key, 1, maxlength)
+local existingscore = redis.call("ZSCORE", key, value)
+if existingscore then
+	-- renumber all the elements and make this one the last
+	local elements = redis.call("ZRANGEBYSCORE", key, 1, maxlength)
+	local i = 1
+	for _, v in ipairs(elements) do
+		if v == value then
+			redis.call("ZADD", key, count, v)
+		else
+			redis.call("ZADD", key, i, v)
+			i = i + 1
+		end
+	end
+	return
+end
+
+if count == maxlength then
+	-- delete the first element, modify the other elements score down
+	-- and add the new one to the end
+	redis.call("ZREMRANGEBYSCORE", key, 1, 1)
+	local elements = redis.call("ZRANGEBYSCORE", key, 2, maxlength)
+	local i = 1
+	for _, v in ipairs(elements) do
+		redis.call("ZADD", key, i, v)
+		i = i + 1
+	end
+	return redis.call("ZADD", key, count, value)
+else
+	-- otherwise just insert it with the next score
+	return redis.call("ZADD", key, count + 1, value)
+end


### PR DESCRIPTION
The IP address is cached in the same sorted set that houses chat IP addresses (the `CHAT:userips-<userId>` key). It counts as one of the three latest IP addresses recorded for each user. Considering it's treated the same way as a chat IP, it automatically shows up in the IPs section of user pages, can be searched for on `/admin/chat`, and is used when trying to identify smurfs.