### PR TITLE
Enhance pay-to-win unban/unmute functionality

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -210,6 +210,7 @@ return [
         'receiver_email' => '',
         'currency' => 'USD',
         'minimum_donation' => 5,
+        'minimum_donation_for_unban' => 5,
         'tiers' => [
             ['tier' => 1, 'tierLabel' => 'Tier I'],
             ['tier' => 2, 'tierLabel' => 'Tier II'],

--- a/lib/Destiny/Chat/ChatBanService.php
+++ b/lib/Destiny/Chat/ChatBanService.php
@@ -294,4 +294,9 @@ class ChatBanService extends Service {
             throw new DBException("Error getting bans for user.", $e);
         }
     }
+
+    public function isPermanentBan(array $ban): bool {
+        // Permanent bans don't have an `endtimestamp`.
+        return empty($ban['endtimestamp']);
+    }
 }

--- a/lib/Destiny/Chat/ChatRedisService.php
+++ b/lib/Destiny/Chat/ChatRedisService.php
@@ -102,7 +102,8 @@ class ChatRedisService extends Service {
         return $this->redis->publish("broadcast-$this->redisdb", json_encode(['data' => $message], JSON_FORCE_OBJECT));
     }
 
-    public function sendUnban(int $userId) {
+    public function sendUnbanAndUnmute(int $userId) {
+        // Publishing to this channel unbans *and* unmutes.
         $this->redis->publish("unbanuserid-$this->redisdb", "$userId");
     }
 

--- a/lib/Destiny/Controllers/ChatSubscriptionController.php
+++ b/lib/Destiny/Controllers/ChatSubscriptionController.php
@@ -174,6 +174,7 @@ class ChatSubscriptionController {
             $userService = UserService::instance();
             $userAuthService = UserAuthService::instance();
             $redisService = ChatRedisService::instance();
+            $chatBanService = ChatBanService::instance();
             $submessage = isset($data['sub_message']) && !empty($data['sub_message']) ? $data['sub_message']['message'] : '';
             $months = isset($data['months']) && !empty($data['months']) && $data['months'] > 0 ? ($data['months'] > 1 ? ' active for ' . $data['months'] . ' months' : ' active for ' . $data['months'] . ' month') : '';
 
@@ -219,6 +220,16 @@ class ChatSubscriptionController {
                     break;
 
             }
+
+            try {
+                $ban = $chatBanService->getUserActiveBan($user['userId']);
+                if (empty($ban) || !$chatBanService->isPermanentBan($ban)) {
+                    $redisService->sendUnbanAndUnmute($user['userId']);
+                }
+            } catch (Exception $e) {
+                Log::error($e->getMessage());
+            }
+
             $response->setStatus(Http::STATUS_NO_CONTENT);
             return null;
         } catch (Exception $e) {

--- a/lib/Destiny/Controllers/DonateController.php
+++ b/lib/Destiny/Controllers/DonateController.php
@@ -103,7 +103,7 @@ class DonateController {
                 'currency' => Config::$a ['commerce'] ['currency'],
                 'amount' => $params['amount'],
                 'status' => DonationStatus::PENDING,
-                'message' => mb_substr($params['message'], 0, 200),
+                'message' => mb_substr($params['message'], 0, 255),
                 'invoiceId' => RandomString::makeUrlSafe(32),
                 'timestamp' => Date::getDateTime()->format('Y-m-d H:i:s')
             ];

--- a/lib/Destiny/Controllers/SubscriptionController.php
+++ b/lib/Destiny/Controllers/SubscriptionController.php
@@ -432,7 +432,7 @@ class SubscriptionController {
         try {
             $ban = $chatBanService->getUserActiveBan($user['userId']);
             if (empty ($ban) or (!empty($ban ['endtimestamp']) or $subscriptionType['tier'] >= 2)) {
-                $redisService->sendUnban($user['userId']);
+                $redisService->sendUnbanAndUnmute($user['userId']);
             }
         } catch (Exception $e) {
             Log::error($e->getMessage());

--- a/lib/Destiny/Controllers/SubscriptionController.php
+++ b/lib/Destiny/Controllers/SubscriptionController.php
@@ -427,11 +427,11 @@ class SubscriptionController {
             return 'redirect: /subscription/' . urlencode($subscription ['subscriptionId']) . '/error';
         }
 
-        // only unban the user if the ban is non-permanent or the tier of the subscription is >= 2
+        // only unban the user if the ban is non-permanent
         // we unban the user if no ban is found because it also unmute's
         try {
             $ban = $chatBanService->getUserActiveBan($user['userId']);
-            if (empty ($ban) or (!empty($ban ['endtimestamp']) or $subscriptionType['tier'] >= 2)) {
+            if (empty ($ban) or !empty($ban ['endtimestamp'])) {
                 $redisService->sendUnbanAndUnmute($user['userId']);
             }
         } catch (Exception $e) {

--- a/lib/Destiny/Controllers/SubscriptionController.php
+++ b/lib/Destiny/Controllers/SubscriptionController.php
@@ -427,11 +427,9 @@ class SubscriptionController {
             return 'redirect: /subscription/' . urlencode($subscription ['subscriptionId']) . '/error';
         }
 
-        // only unban the user if the ban is non-permanent
-        // we unban the user if no ban is found because it also unmute's
         try {
             $ban = $chatBanService->getUserActiveBan($user['userId']);
-            if (empty ($ban) or !empty($ban ['endtimestamp'])) {
+            if (empty($ban) || !$chatBanService->isPermanentBan($ban)) {
                 $redisService->sendUnbanAndUnmute($user['userId']);
             }
         } catch (Exception $e) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dgg-website",
-  "version": "2.18.0",
+  "version": "2.19.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dgg-website",
-  "version": "2.18.0",
+  "version": "2.19.0",
   "description": "Destiny.gg front-end",
   "main": "destiny",
   "scripts": {

--- a/views/donate.php
+++ b/views/donate.php
@@ -1,5 +1,6 @@
 <?php
 namespace Destiny;
+use Destiny\Common\Config;
 use Destiny\Common\Session\Session;
 use Destiny\Common\User\UserRole;
 use Destiny\Common\Utils\Tpl;
@@ -47,6 +48,7 @@ use Destiny\Common\Utils\Tpl;
                         <label class="sr-only" for="amount">Amount (in dollars)</label>
                         <input class="form-control required number" id="amount" name="amount" placeholder="5.00" autofocus />
                         <div id="donation-amount-currency">$</div>
+                        <span class="help-block">Donate $<?= Config::$a['commerce']['minimum_donation_for_unban'] ?> or more remove a non-permanent ban or mute in chat.</span>
                     </div>
                 </div>
                 <div class="ds-block text-message">

--- a/views/donate.php
+++ b/views/donate.php
@@ -52,7 +52,7 @@ use Destiny\Common\Utils\Tpl;
                     </div>
                 </div>
                 <div class="ds-block text-message">
-                    <textarea name="message" autocomplete="off" maxlength="200" rows="3" class="form-control" placeholder="Write a message ..."></textarea>
+                    <textarea name="message" autocomplete="off" maxlength="255" rows="3" class="form-control" placeholder="Write a message ..."></textarea>
                 </div>
                 <div class="form-actions">
                     <button class="btn btn-primary btn-lg"><i class="fas fa-shopping-cart"></i> Continue</button>

--- a/views/profile/account.php
+++ b/views/profile/account.php
@@ -49,7 +49,7 @@ use Destiny\Common\Config;
                         </dl>
                         <hr/>
                         <p>
-                            Any non-permanent bans are removed when subscribing as well as any mutes (there are no permanent mutes, maximum 6 days long).<br>
+                            Non-permanent bans and mutes are removed when you subscribe or donate. Mutes are always temporary.<br>
                             This is not meant to be a cash grab, rather a tool for those who would not like to wait for a manual unban or for the ban to naturally expire and are willing to pay for it.<br>
                             <?php if(!empty(Config::$a['banAppealUrl'])): ?>
                                 Please visit <a target="_blank" href="<?= Config::$a['banAppealUrl'] ?>"><?= Config::$a['banAppealUrl'] ?></a> to appeal your ban.


### PR DESCRIPTION
Currently, a user's only option for ending a ban or mute early (besides begging RTBA for mercy) is to purchase a website subscription on the `/subscribe` page. Any sub removes a temporary ban/mute, but only a tier 2 or higher sub removes a permanent ban/mute.

This PR shakes things up by allowing users to website sub, Twitch sub, or website donate to save themselves. For website donations, they have to donate a minimum amount as specified by `minimum_donation_for_unban` in the config ($5 by default). Also, in order to really stick it to egregious rule offenders, users can no longer recover from a permanent ban, no matter how much they sub or donate.

As a bonus, I updated website donations to allow for messages up to 255 characters in length, up from 200. This is the same limit enforced by StreamLabs on their donation page.