### PR TITLE
[#174] - Resolves unresponsive streamlabs link

### DIFF
--- a/views/donate.php
+++ b/views/donate.php
@@ -18,15 +18,10 @@ use Destiny\Common\Utils\Tpl;
     <?php include 'seg/nav.php' ?>
 
     <section class="container">
-
-        <h1 class="title" style="display: flex; align-items: center;">
-            <span>Donate</span>
-            <small>&nbsp;(send a message too)</small>
-            <span style="flex: 2; display: flex; justify-content: flex-end; align-items: center;">
-                <small>prefer? &nbsp;</small>
-                <a href="https://streamlabs.com/destiny" class="streamlabs-logo"></a>
-            </span>
-        </h1>
+        <div class="title d-flex align-items-center">
+            <h1>Donate</h1>
+            <span>&nbsp;(send a message too)</span>
+        </div>
 
         <div class="content content-dark clearfix">
             <form id="donateform" class="validate" action="/donate" method="post">
@@ -62,7 +57,12 @@ use Destiny\Common\Utils\Tpl;
         </div>
 
         <p class="agreement">By clicking the &quot;Continue&quot; button, you are confirming that this purchase is what you wanted and that you have read the <a href="/agreement">user agreement</a>.</p>
-
+        </br>
+        <div class="d-flex align-items-center justify-content-end">
+            <span>prefer &nbsp;</span>
+            <a href="https://streamlabs.com/destiny" class="streamlabs-logo"></a>
+            <span>&nbsp;?</span>
+        </div>
     </section>
 
 </div>


### PR DESCRIPTION
- Moved streamlabs link to below the form

There are likely other implementations of this work, but I figure the general aim has been to push people towards the website for donations and subs.  So accordingly I have made the link for streamlabs donation lower on the page.  An alternative would be to just break to the next line instead, or as alluded to in the request before, removing content.

![image](https://user-images.githubusercontent.com/19414122/95675303-cfcaf600-0b7b-11eb-9999-d4ae1bf993d3.png)
![image](https://user-images.githubusercontent.com/19414122/95675317-f557ff80-0b7b-11eb-9e02-954b20437f54.png)
![image](https://user-images.githubusercontent.com/19414122/95675323-01dc5800-0b7c-11eb-8fec-c12d3c16f906.png)
![image](https://user-images.githubusercontent.com/19414122/95675332-102a7400-0b7c-11eb-8a3f-2ed5674437e5.png)

