### PR TITLE
Send StreamLabs alerts for all subs, resubs, direct gifts, and mass gifts

### DIFF
--- a/lib/Destiny/Controllers/SubscriptionController.php
+++ b/lib/Destiny/Controllers/SubscriptionController.php
@@ -266,7 +266,8 @@ class SubscriptionController {
             );
             return 'redirect: ' . Config::$a['paypal']['endpoint_checkout'] . urlencode($token);
         } catch (Exception $e) {
-            throw new Exception('Error creating order.', $e);
+            Log::critical("Error creating order. {$e}");
+            return 'redirect: /subscription/error';
         }
     }
 

--- a/lib/Destiny/StreamLabs/StreamLabsService.php
+++ b/lib/Destiny/StreamLabs/StreamLabsService.php
@@ -67,4 +67,82 @@ class StreamLabsService extends AbstractAuthService {
         return null;
     }
 
+    public function sendSubAlert(array $subscriptionType, ?string $message, string $username) {
+        $this->sendAlert([
+            'type' => StreamLabsAlertsType::ALERT_SUBSCRIPTION,
+            'message' => $this->trimAlertMessage($message),
+            'user_message' => $this->buildEventMetadata(
+                SubAlertEvent::SUB,
+                [
+                    'user' => $username,
+                    'tier' => $subscriptionType['tier'],
+                    'tierLabel' => $subscriptionType['tierLabel']
+                ]
+            )
+        ]);
+    }
+
+    public function sendResubAlert(array $subscriptionType, ?string $message, string $username, int $streak) {
+        $this->sendAlert([
+            'type' => StreamLabsAlertsType::ALERT_SUBSCRIPTION,
+            'message' => $this->trimAlertMessage($message),
+            'user_message' => $this->buildEventMetadata(
+                SubAlertEvent::RESUB,
+                [
+                    'user' => $username,
+                    'tier' => $subscriptionType['tier'],
+                    'tierLabel' => $subscriptionType['tierLabel'],
+                    'streak' => $streak
+                ]
+            )
+        ]);
+    }
+
+    public function sendDirectGiftAlert(array $subscriptionType, ?string $message, string $username, string $giftee) {
+        $this->sendAlert([
+            'type' => StreamLabsAlertsType::ALERT_SUBSCRIPTION,
+            'message' => $this->trimAlertMessage($message),
+            'user_message' => $this->buildEventMetadata(
+                SubAlertEvent::DIRECT_GIFT,
+                [
+                    'user' => $username,
+                    'tier' => $subscriptionType['tier'],
+                    'tierLabel' => $subscriptionType['tierLabel'],
+                    'giftee' => $giftee
+                ]
+            )
+        ]);
+    }
+
+    public function sendMassGiftAlert(array $subscriptionType, ?string $message, string $username, int $quantity) {
+        $this->sendAlert([
+            'type' => StreamLabsAlertsType::ALERT_SUBSCRIPTION,
+            'message' => $this->trimAlertMessage($message),
+            'user_message' => $this->buildEventMetadata(
+                SubAlertEvent::MASS_GIFT,
+                [
+                    'user' => $username,
+                    'tier' => $subscriptionType['tier'],
+                    'tierLabel' => $subscriptionType['tierLabel'],
+                    'quantity' => $quantity
+                ]
+            )
+        ]);
+    }
+
+    /**
+     * Encodes additional alert data for use in StreamLabs' `/alerts` endpoint.
+     * Passed in via the `user_message` parameter.
+     */
+    private function buildEventMetadata(string $event, array $data) {
+        return json_encode([
+            'source' => 'dgg',
+            'event' => $event,
+            'data' => $data
+        ]);
+    }
+
+    private function trimAlertMessage(?string $message): string {
+        return mb_substr(trim($message), 0, 250);
+    }
 }

--- a/lib/Destiny/StreamLabs/SubAlertEvent.php
+++ b/lib/Destiny/StreamLabs/SubAlertEvent.php
@@ -1,0 +1,10 @@
+<?php
+namespace Destiny\StreamLabs;
+
+class SubAlertEvent {
+
+    const SUB = 'sub';
+    const RESUB = 'resub';
+    const DIRECT_GIFT = 'directGift';
+    const MASS_GIFT = 'massGift';
+}

--- a/lib/boot.app.php
+++ b/lib/boot.app.php
@@ -11,7 +11,7 @@ use Monolog\Handler\StreamHandler;
 use Monolog\Logger;
 use Monolog\Processor\PsrLogMessageProcessor;
 
-define('_APP_VERSION', '2.20.2'); // auto-generated: 1603254789227
+define('_APP_VERSION', '2.21.0'); // auto-generated: 1603439173073
 define('_BASEDIR', realpath(__DIR__ . '/../'));
 
 $loader = require _BASEDIR . '/vendor/autoload.php';

--- a/lib/boot.test.php
+++ b/lib/boot.test.php
@@ -8,7 +8,7 @@ use Monolog\Handler\StreamHandler;
 use Monolog\Logger;
 use Monolog\Processor\PsrLogMessageProcessor;
 
-define('_APP_VERSION', '2.20.2'); // auto-generated: 1603254789233
+define('_APP_VERSION', '2.21.0'); // auto-generated: 1603439173079
 define('_BASEDIR', realpath(__DIR__ . '/../'));
 
 $loader = require _BASEDIR . '/vendor/autoload.php';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dgg-website",
-  "version": "2.20.2",
+  "version": "2.21.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dgg-website",
-  "version": "2.20.2",
+  "version": "2.21.0",
   "description": "Destiny.gg front-end",
   "main": "destiny",
   "scripts": {


### PR DESCRIPTION
Currently, we only send an alert to StreamLabs for subs and gift subs when a broadcast message is provided. With this PR, we do so for every sub, resub, direct gift, and mass gift, regardless of whether or not there's a message. We also pass JSON-encoded metadata about the event via the `user_message` parameter so the receiving alert JS knows what happened.