### PR TITLE
Subscription bugfixes

### DIFF
--- a/assets/web/js/web.js
+++ b/assets/web/js/web.js
@@ -617,6 +617,26 @@ const $document = $(document),
         // Submit form normally after updating inputs.
         return true
     })
-})()
+})();
+
+// For `/subscription/confirm`.
+(function() {
+    const $confirmSubscriptionForm = $('form#subscribe-form')
+    const $submitButton = $confirmSubscriptionForm.find('button[type="submit"]')
+
+    const showLoadingIcon = () => {
+        const $icon = $submitButton.find('i')
+        $icon.removeClass('fa-shopping-cart')
+        $icon.addClass('fa-spinner fa-pulse')
+    }
+
+    // Ensure the button can only be clicked once.
+    $submitButton.click(() => {
+        $submitButton.prop('disabled', true)
+        showLoadingIcon()
+
+        $confirmSubscriptionForm.submit()
+    })
+})();
 
 window.showLoginModal = () => $('#loginmodal').modal("show")

--- a/lib/Destiny/StreamLabs/StreamLabsService.php
+++ b/lib/Destiny/StreamLabs/StreamLabsService.php
@@ -67,10 +67,10 @@ class StreamLabsService extends AbstractAuthService {
         return null;
     }
 
-    public function sendSubAlert(array $subscriptionType, ?string $message, string $username) {
+    public function sendSubAlert(array $subscriptionType, string $message, string $username) {
         $this->sendAlert([
             'type' => StreamLabsAlertsType::ALERT_SUBSCRIPTION,
-            'message' => $this->trimAlertMessage($message),
+            'message' => $message,
             'user_message' => $this->buildEventMetadata(
                 SubAlertEvent::SUB,
                 [
@@ -82,10 +82,10 @@ class StreamLabsService extends AbstractAuthService {
         ]);
     }
 
-    public function sendResubAlert(array $subscriptionType, ?string $message, string $username, int $streak) {
+    public function sendResubAlert(array $subscriptionType, string $message, string $username, int $streak) {
         $this->sendAlert([
             'type' => StreamLabsAlertsType::ALERT_SUBSCRIPTION,
-            'message' => $this->trimAlertMessage($message),
+            'message' => $message,
             'user_message' => $this->buildEventMetadata(
                 SubAlertEvent::RESUB,
                 [
@@ -98,10 +98,10 @@ class StreamLabsService extends AbstractAuthService {
         ]);
     }
 
-    public function sendDirectGiftAlert(array $subscriptionType, ?string $message, string $username, string $giftee) {
+    public function sendDirectGiftAlert(array $subscriptionType, string $message, string $username, string $giftee) {
         $this->sendAlert([
             'type' => StreamLabsAlertsType::ALERT_SUBSCRIPTION,
-            'message' => $this->trimAlertMessage($message),
+            'message' => $message,
             'user_message' => $this->buildEventMetadata(
                 SubAlertEvent::DIRECT_GIFT,
                 [
@@ -114,10 +114,10 @@ class StreamLabsService extends AbstractAuthService {
         ]);
     }
 
-    public function sendMassGiftAlert(array $subscriptionType, ?string $message, string $username, int $quantity) {
+    public function sendMassGiftAlert(array $subscriptionType, string $message, string $username, int $quantity) {
         $this->sendAlert([
             'type' => StreamLabsAlertsType::ALERT_SUBSCRIPTION,
-            'message' => $this->trimAlertMessage($message),
+            'message' => $message,
             'user_message' => $this->buildEventMetadata(
                 SubAlertEvent::MASS_GIFT,
                 [
@@ -140,9 +140,5 @@ class StreamLabsService extends AbstractAuthService {
             'event' => $event,
             'data' => $data
         ]);
-    }
-
-    private function trimAlertMessage(?string $message): string {
-        return mb_substr(trim($message), 0, 250);
     }
 }

--- a/lib/Destiny/Tasks/SubscriptionExpire.php
+++ b/lib/Destiny/Tasks/SubscriptionExpire.php
@@ -107,7 +107,7 @@ class SubscriptionExpire implements TaskInterface {
 
                 StreamLabsService::instance()->sendResubAlert(
                     $subType,
-                    null,
+                    '',
                     $user['username'],
                     $streak
                 );

--- a/lib/boot.app.php
+++ b/lib/boot.app.php
@@ -11,7 +11,7 @@ use Monolog\Handler\StreamHandler;
 use Monolog\Logger;
 use Monolog\Processor\PsrLogMessageProcessor;
 
-define('_APP_VERSION', '2.21.0'); // auto-generated: 1603439173073
+define('_APP_VERSION', '2.21.1'); // auto-generated: 1603668478728
 define('_BASEDIR', realpath(__DIR__ . '/../'));
 
 $loader = require _BASEDIR . '/vendor/autoload.php';

--- a/lib/boot.test.php
+++ b/lib/boot.test.php
@@ -8,7 +8,7 @@ use Monolog\Handler\StreamHandler;
 use Monolog\Logger;
 use Monolog\Processor\PsrLogMessageProcessor;
 
-define('_APP_VERSION', '2.21.0'); // auto-generated: 1603439173079
+define('_APP_VERSION', '2.21.1'); // auto-generated: 1603668478734
 define('_BASEDIR', realpath(__DIR__ . '/../'));
 
 $loader = require _BASEDIR . '/vendor/autoload.php';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dgg-website",
-  "version": "2.21.0",
+  "version": "2.21.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dgg-website",
-  "version": "2.21.0",
+  "version": "2.21.1",
   "description": "Destiny.gg front-end",
   "main": "destiny",
   "scripts": {


### PR DESCRIPTION
* #230 introduced a bug where broadcast messages were no longer printed to chat. This PR fixes the issue.
* It takes a little time to initialize a PayPal transaction when clicking the Continue button on the `/subscription/confirm` page. An impatient user may click the button multiple times, which could have unexpected effects. This PR disables the button after one click to prevent this from happening.