### PR TITLE
Display active sub stats on `/admin/income` page

### DIFF
--- a/assets/web/css/style.scss
+++ b/assets/web/css/style.scss
@@ -2333,3 +2333,49 @@ div.two-tone-button {
         }
     }
 }
+
+div.active-sub-count {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+
+    padding: 20px;
+
+    h4 {
+        color: $text-color;
+    }
+
+    table {
+        background: #1d1d1d;
+        margin-bottom: 20px;
+        border-radius: 3px;
+
+        th, td {
+            padding: 8px;
+        }
+
+        th {
+            text-align: right;
+            text-transform: uppercase;
+            font-size: 0.8rem;
+            color: $text-color2;
+        }
+
+        td {
+            text-align: center;
+        }
+
+        tr:not(:first-child) {
+            border-top: 1px dotted #383838;
+        }
+
+        col:not(:last-child) {
+            border-right: 1px dotted #383838;
+        }
+
+        tr:last-child td:last-child {
+            font-weight: bold;
+            font-size: 1.1rem;
+        }
+    }
+}

--- a/assets/web/js/admin.income.js
+++ b/assets/web/js/admin.income.js
@@ -422,8 +422,39 @@ import Chart from 'chart.js'
                     labels: Array.from(data.keys()),
                     datasets: [{
                         label: `Tier ${tier} Subs`,
-                        data: Array.from(data.values())
+                        data: Array.from(data.values()),
+                        borderColor: 'rgba(51, 122, 183, 1)',
+                        pointBorderColor: 'rgba(51, 122, 183, 1)',
+                        pointBackgroundColor: 'rgba(51, 122, 183, 1)'
                     }]
+                },
+                options: {
+                    aspectRatio: 1.5,
+                    title: {
+                        display: true,
+                        text: `Active Tier ${tier} Subs`
+                    },
+                    legend: {
+                        display: false
+                    },
+                    scales: {
+                        xAxes: [{
+                            type: 'time',
+                            time: {
+                                parser: 'YYYY-MM-DD',
+                                tooltipFormat: 'MM/DD/YY',
+                                unit: 'day',
+                                displayFormats: {
+                                    'day': 'MM/DD'
+                                }
+                            }
+                        }],
+                        yAxes: [{
+                            ticks: {
+                                precision: 0
+                            }
+                        }]
+                    }
                 }
             })
         }

--- a/assets/web/js/admin.income.js
+++ b/assets/web/js/admin.income.js
@@ -342,8 +342,8 @@ import Chart from 'chart.js'
 
         const TIERS = [1, 2, 3, 4]
         const DAYS_BACK = 30
-        const now = moment()
-        const then = moment(now).subtract(DAYS_BACK, 'd')
+        const now = moment.utc()
+        const then = moment.utc(now).subtract(DAYS_BACK, 'd')
 
         const updateActiveSubCountTables = data => {
             data.forEach(countRecord => {
@@ -381,25 +381,25 @@ import Chart from 'chart.js'
             // Create a new map of the last 30 days.
             let counts = new Map()
             for (let i = DAYS_BACK - 1; i >= 0; i--) {
-                const day = moment(now).subtract(i, 'd').format('YYYY-MM-DD')
+                const day = moment.utc(now).subtract(i, 'd').format('YYYY-MM-DD')
                 counts.set(day, 0)
             }
 
             const filtered = data.filter(sub => sub['subscriptionTier'] === tier.toString())
             filtered.forEach(sub => {
                 // Don't go beyond the earliest or latest days in the graph.
-                let start = moment(sub['createdDate'])
+                let start = moment.utc(sub['createdDate'])
                 if (start.isBefore(then, 'd')) {
-                    start = moment(then)
+                    start = moment.utc(then)
                 }
-                let end = moment(sub['endDate'])
+                let end = moment.utc(sub['endDate'])
                 if (end.isAfter(now, 'd')) {
-                    end = moment(now)
+                    end = moment.utc(now)
                 }
 
                 // Account for subs that were canceled before their end date.
                 if (sub['cancelDate']) {
-                    const cancel = moment(sub['cancelDate'])
+                    const cancel = moment.utc(sub['cancelDate'])
                     if (end.isAfter(cancel, 'd')) {
                         end = cancel
                     }
@@ -439,6 +439,10 @@ import Chart from 'chart.js'
                     },
                     scales: {
                         xAxes: [{
+                            scaleLabel: {
+                                display: true,
+                                labelString: 'UTC'
+                            },
                             type: 'time',
                             time: {
                                 parser: 'YYYY-MM-DD',

--- a/assets/web/js/admin.income.js
+++ b/assets/web/js/admin.income.js
@@ -340,6 +340,47 @@ import Chart from 'chart.js'
             updateGraph5(currDate);
         });
 
-    });
+        const updateActiveSubCountTables = data => {
+            data.forEach(countRecord => {
+                const {subscriptionType, recurring, count} = countRecord
+                $(`td[data-sub-type='${subscriptionType}'][data-recurring='${recurring}']`).text(count)
+            })
 
+            // Add values across each row.
+            $('td:last-child').each((_, e) => {
+                const $total = $(e)
+                $total.text(0)
+
+                let count = 0
+                $total.siblings('td').each((_, e) => {
+                    count += parseInt($(e).text())
+                })
+                $total.text(count)
+            })
+
+            // Add values down each column.
+            $('tr:last-child td').each((_, e) => {
+                const $total = $(e)
+                $total.text(0)
+
+                let count = 0
+                const $table = $total.parents('table')
+                $table.find(`td:nth-child(${$total.index() + 1})`).each((_, e) => {
+                    count += parseInt($(e).text())
+                })
+                $total.text(count)
+            })
+        }
+
+        const fetchActiveSubCounts = () => {
+            $.ajax({
+                url: '/admin/chart/finance/CurrentActiveSubs.json',
+                success: data => {
+                    updateActiveSubCountTables(data)
+                }
+            })
+        }
+
+        fetchActiveSubCounts()
+    });
 })(jQuery)

--- a/lib/Destiny/Commerce/StatisticsService.php
+++ b/lib/Destiny/Commerce/StatisticsService.php
@@ -280,5 +280,29 @@ class StatisticsService extends Service {
         }
     }
 
-
+    /**
+     * Gets active subs grouped by type and recurring status.
+     *
+     * @throws DBException
+     */
+    public function getActiveSubCounts(): array {
+        try {
+            $conn = Application::getDbConn();
+            $stmt = $conn->executeQuery(
+                'SELECT
+                    `subscriptionType`, `recurring`, count(*) as `count`
+                FROM
+                    `dfl_users_subscriptions`
+                WHERE
+                    `status` = ?
+                GROUP BY
+                    `subscriptionType`, `recurring`',
+                [SubscriptionStatus::ACTIVE],
+                [PDO::PARAM_STR]
+            );
+            return $stmt->fetchAll();
+        } catch (DBALException $e) {
+            throw new DBException('Error getting active subs.', $e);
+        }
+    }
 }

--- a/lib/Destiny/Controllers/AdminController.php
+++ b/lib/Destiny/Controllers/AdminController.php
@@ -382,6 +382,9 @@ class AdminController {
                         $data = $cacheDriver->fetch($key);
                     }
                     break;
+                case 'CURRENTACTIVESUBS':
+                    $data = $statisticsService->getActiveSubCounts();
+                    break;
             }
         } catch (Exception $e) {
             Log::error('Error loading graph data. ' . $e->getMessage());

--- a/lib/Destiny/Controllers/AdminController.php
+++ b/lib/Destiny/Controllers/AdminController.php
@@ -385,6 +385,9 @@ class AdminController {
                 case 'CURRENTACTIVESUBS':
                     $data = $statisticsService->getActiveSubCounts();
                     break;
+                case 'HISTORICALACTIVESUBS':
+                    $data = $statisticsService->getHistoricalActiveSubs();
+                    break;
             }
         } catch (Exception $e) {
             Log::error('Error loading graph data. ' . $e->getMessage());

--- a/lib/Destiny/Controllers/AdminController.php
+++ b/lib/Destiny/Controllers/AdminController.php
@@ -59,6 +59,28 @@ class AdminController {
      * @return string
      */
     public function income(ViewModel $model) {
+        $model->subInfo = [
+            [
+                'tierLabel' => 'Tier I',
+                'oneMonthSubId' => '1-MONTH-SUB',
+                'threeMonthSubId' => '3-MONTH-SUB'
+            ],
+            [
+                'tierLabel' => 'Tier II',
+                'oneMonthSubId' => '1-MONTH-SUB2',
+                'threeMonthSubId' => '3-MONTH-SUB2'
+            ],
+            [
+                'tierLabel' => 'Tier III',
+                'oneMonthSubId' => '1-MONTH-SUB3',
+                'threeMonthSubId' => '3-MONTH-SUB3'
+            ],
+            [
+                'tierLabel' => 'Tier IV',
+                'oneMonthSubId' => '1-MONTH-SUB4',
+                'threeMonthSubId' => '3-MONTH-SUB4'
+            ]
+        ];
         $model->title = 'Income';
         return 'admin/income';
     }

--- a/lib/boot.app.php
+++ b/lib/boot.app.php
@@ -11,7 +11,7 @@ use Monolog\Handler\StreamHandler;
 use Monolog\Logger;
 use Monolog\Processor\PsrLogMessageProcessor;
 
-define('_APP_VERSION', '2.21.1'); // auto-generated: 1603668478728
+define('_APP_VERSION', '2.22.0'); // auto-generated: 1603865348666
 define('_BASEDIR', realpath(__DIR__ . '/../'));
 
 $loader = require _BASEDIR . '/vendor/autoload.php';

--- a/lib/boot.test.php
+++ b/lib/boot.test.php
@@ -8,7 +8,7 @@ use Monolog\Handler\StreamHandler;
 use Monolog\Logger;
 use Monolog\Processor\PsrLogMessageProcessor;
 
-define('_APP_VERSION', '2.21.1'); // auto-generated: 1603668478734
+define('_APP_VERSION', '2.22.0'); // auto-generated: 1603865348672
 define('_BASEDIR', realpath(__DIR__ . '/../'));
 
 $loader = require _BASEDIR . '/vendor/autoload.php';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dgg-website",
-  "version": "2.21.1",
+  "version": "2.22.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dgg-website",
-  "version": "2.21.1",
+  "version": "2.22.0",
   "description": "Destiny.gg front-end",
   "main": "destiny",
   "scripts": {

--- a/views/admin/income.php
+++ b/views/admin/income.php
@@ -15,9 +15,9 @@ use Destiny\Common\Utils\Tpl;
     <?php include 'seg/admin.nav.php' ?>
 
     <section class="container">
-        <div class="row">
+        <div class="row mb-2">
             <div class="col-xxl-3 col-lg-6 col-md-12">
-                <div>
+                <div class="active-sub-count graph-outer">
                     <h4>Tier I</h4>
                     <table>
                         <colgroup>
@@ -55,7 +55,7 @@ use Destiny\Common\Utils\Tpl;
                 </div>
             </div>
             <div class="col-xxl-3 col-lg-6 col-md-12">
-                <div>
+                <div class="active-sub-count graph-outer">
                     <h4>Tier II</h4>
                     <table>
                         <colgroup>
@@ -93,7 +93,7 @@ use Destiny\Common\Utils\Tpl;
                 </div>
             </div>
             <div class="col-xxl-3 col-lg-6 col-md-12">
-                <div>
+                <div class="active-sub-count graph-outer">
                     <h4>Tier III</h4>
                     <table>
                         <colgroup>
@@ -131,7 +131,7 @@ use Destiny\Common\Utils\Tpl;
                 </div>
             </div>
             <div class="col-xxl-3 col-lg-6 col-md-12">
-                <div>
+                <div class="active-sub-count graph-outer">
                     <h4>Tier IV</h4>
                     <table>
                         <colgroup>

--- a/views/admin/income.php
+++ b/views/admin/income.php
@@ -16,158 +16,46 @@ use Destiny\Common\Utils\Tpl;
 
     <section class="container">
         <div class="row mb-2">
-            <div class="col-xxl-3 col-lg-6 col-md-12">
-                <div class="active-sub-count graph-outer">
-                    <h4>Tier I</h4>
-                    <table>
-                        <colgroup>
-                            <col>
-                            <col>
-                            <col>
-                            <col>
-                        </colgroup>
-                        <tr>
-                            <th></th>
-                            <th>Not Recurring</th>
-                            <th>Recurring</th>
-                            <th>Total</th>
-                        </tr>
-                        <tr>
-                            <th>1 Month</th>
-                            <td data-sub-type="1-MONTH-SUB" data-recurring="0">0</td>
-                            <td data-sub-type="1-MONTH-SUB" data-recurring="1">0</td>
-                            <td>0</td>
-                        </tr>
-                        <tr>
-                            <th>3 Month</th>
-                            <td data-sub-type="3-MONTH-SUB" data-recurring="0">0</td>
-                            <td data-sub-type="3-MONTH-SUB" data-recurring="1">0</td>
-                            <td>0</td>
-                        </tr>
-                        <tr>
-                            <th>Total</th>
-                            <td>0</td>
-                            <td>0</td>
-                            <td>0</td>
-                        </tr>
-                    </table>
-                    <canvas data-tier="1"></canvas>
+            <?php foreach ($this->subInfo as $key => $value): ?>
+                <div class="col-xxl-3 col-lg-6 col-md-12">
+                    <div class="active-sub-count graph-outer">
+                        <h4><?= $value['tierLabel'] ?></h4>
+                        <table>
+                            <colgroup>
+                                <col>
+                                <col>
+                                <col>
+                                <col>
+                            </colgroup>
+                            <tr>
+                                <th></th>
+                                <th>Not Recurring</th>
+                                <th>Recurring</th>
+                                <th>Total</th>
+                            </tr>
+                            <tr>
+                                <th>1 Month</th>
+                                <td data-sub-type="<?= $value['oneMonthSubId'] ?>" data-recurring="0">0</td>
+                                <td data-sub-type="<?= $value['oneMonthSubId'] ?>" data-recurring="1">0</td>
+                                <td>0</td>
+                            </tr>
+                            <tr>
+                                <th>3 Month</th>
+                                <td data-sub-type="<?= $value['threeMonthSubId'] ?>" data-recurring="0">0</td>
+                                <td data-sub-type="<?= $value['threeMonthSubId'] ?>" data-recurring="1">0</td>
+                                <td>0</td>
+                            </tr>
+                            <tr>
+                                <th>Total</th>
+                                <td>0</td>
+                                <td>0</td>
+                                <td>0</td>
+                            </tr>
+                        </table>
+                        <canvas data-tier="<?= $key + 1 ?>"></canvas>
+                    </div>
                 </div>
-            </div>
-            <div class="col-xxl-3 col-lg-6 col-md-12">
-                <div class="active-sub-count graph-outer">
-                    <h4>Tier II</h4>
-                    <table>
-                        <colgroup>
-                            <col>
-                            <col>
-                            <col>
-                            <col>
-                        </colgroup>
-                        <tr>
-                            <th></th>
-                            <th>Not Recurring</th>
-                            <th>Recurring</th>
-                            <th>Total</th>
-                        </tr>
-                        <tr>
-                            <th>1 Month</th>
-                            <td data-sub-type="1-MONTH-SUB2" data-recurring="0">0</td>
-                            <td data-sub-type="1-MONTH-SUB2" data-recurring="1">0</td>
-                            <td>0</td>
-                        </tr>
-                        <tr>
-                            <th>3 Month</th>
-                            <td data-sub-type="3-MONTH-SUB2" data-recurring="0">0</td>
-                            <td data-sub-type="3-MONTH-SUB2" data-recurring="1">0</td>
-                            <td>0</td>
-                        </tr>
-                        <tr>
-                            <th>Total</th>
-                            <td>0</td>
-                            <td>0</td>
-                            <td>0</td>
-                        </tr>
-                    </table>
-                    <canvas data-tier="2"></canvas>
-                </div>
-            </div>
-            <div class="col-xxl-3 col-lg-6 col-md-12">
-                <div class="active-sub-count graph-outer">
-                    <h4>Tier III</h4>
-                    <table>
-                        <colgroup>
-                            <col>
-                            <col>
-                            <col>
-                            <col>
-                        </colgroup>
-                        <tr>
-                            <th></th>
-                            <th>Not Recurring</th>
-                            <th>Recurring</th>
-                            <th>Total</th>
-                        </tr>
-                        <tr>
-                            <th>1 Month</th>
-                            <td data-sub-type="1-MONTH-SUB3" data-recurring="0">0</td>
-                            <td data-sub-type="1-MONTH-SUB3" data-recurring="1">0</td>
-                            <td>0</td>
-                        </tr>
-                        <tr>
-                            <th>3 Month</th>
-                            <td data-sub-type="3-MONTH-SUB3" data-recurring="0">0</td>
-                            <td data-sub-type="3-MONTH-SUB3" data-recurring="1">0</td>
-                            <td>0</td>
-                        </tr>
-                        <tr>
-                            <th>Total</th>
-                            <td>0</td>
-                            <td>0</td>
-                            <td>0</td>
-                        </tr>
-                    </table>
-                    <canvas data-tier="3"></canvas>
-                </div>
-            </div>
-            <div class="col-xxl-3 col-lg-6 col-md-12">
-                <div class="active-sub-count graph-outer">
-                    <h4>Tier IV</h4>
-                    <table>
-                        <colgroup>
-                            <col>
-                            <col>
-                            <col>
-                            <col>
-                        </colgroup>
-                        <tr>
-                            <th></th>
-                            <th>Not Recurring</th>
-                            <th>Recurring</th>
-                            <th>Total</th>
-                        </tr>
-                        <tr>
-                            <th>1 Month</th>
-                            <td data-sub-type="1-MONTH-SUB4" data-recurring="0">0</td>
-                            <td data-sub-type="1-MONTH-SUB4" data-recurring="1">0</td>
-                            <td>0</td>
-                        </tr>
-                        <tr>
-                            <th>3 Month</th>
-                            <td data-sub-type="3-MONTH-SUB4" data-recurring="0">0</td>
-                            <td data-sub-type="3-MONTH-SUB4" data-recurring="1">0</td>
-                            <td>0</td>
-                        </tr>
-                        <tr>
-                            <th>Total</th>
-                            <td>0</td>
-                            <td>0</td>
-                            <td>0</td>
-                        </tr>
-                    </table>
-                    <canvas data-tier="4"></canvas>
-                </div>
-            </div>
+            <?php endforeach; ?>
         </div>
         <h3 id="income-dates">
             <span id="date-selector">

--- a/views/admin/income.php
+++ b/views/admin/income.php
@@ -51,6 +51,7 @@ use Destiny\Common\Utils\Tpl;
                             <td>0</td>
                         </tr>
                     </table>
+                    <canvas data-tier="1"></canvas>
                 </div>
             </div>
             <div class="col-xxl-3 col-lg-6 col-md-12">
@@ -88,6 +89,7 @@ use Destiny\Common\Utils\Tpl;
                             <td>0</td>
                         </tr>
                     </table>
+                    <canvas data-tier="2"></canvas>
                 </div>
             </div>
             <div class="col-xxl-3 col-lg-6 col-md-12">
@@ -125,6 +127,7 @@ use Destiny\Common\Utils\Tpl;
                             <td>0</td>
                         </tr>
                     </table>
+                    <canvas data-tier="3"></canvas>
                 </div>
             </div>
             <div class="col-xxl-3 col-lg-6 col-md-12">
@@ -162,6 +165,7 @@ use Destiny\Common\Utils\Tpl;
                             <td>0</td>
                         </tr>
                     </table>
+                    <canvas data-tier="4"></canvas>
                 </div>
             </div>
         </div>

--- a/views/admin/income.php
+++ b/views/admin/income.php
@@ -15,6 +15,156 @@ use Destiny\Common\Utils\Tpl;
     <?php include 'seg/admin.nav.php' ?>
 
     <section class="container">
+        <div class="row">
+            <div class="col-xxl-3 col-lg-6 col-md-12">
+                <div>
+                    <h4>Tier I</h4>
+                    <table>
+                        <colgroup>
+                            <col>
+                            <col>
+                            <col>
+                            <col>
+                        </colgroup>
+                        <tr>
+                            <th></th>
+                            <th>Not Recurring</th>
+                            <th>Recurring</th>
+                            <th>Total</th>
+                        </tr>
+                        <tr>
+                            <th>1 Month</th>
+                            <td data-sub-type="1-MONTH-SUB" data-recurring="0">0</td>
+                            <td data-sub-type="1-MONTH-SUB" data-recurring="1">0</td>
+                            <td>0</td>
+                        </tr>
+                        <tr>
+                            <th>3 Month</th>
+                            <td data-sub-type="3-MONTH-SUB" data-recurring="0">0</td>
+                            <td data-sub-type="3-MONTH-SUB" data-recurring="1">0</td>
+                            <td>0</td>
+                        </tr>
+                        <tr>
+                            <th>Total</th>
+                            <td>0</td>
+                            <td>0</td>
+                            <td>0</td>
+                        </tr>
+                    </table>
+                </div>
+            </div>
+            <div class="col-xxl-3 col-lg-6 col-md-12">
+                <div>
+                    <h4>Tier II</h4>
+                    <table>
+                        <colgroup>
+                            <col>
+                            <col>
+                            <col>
+                            <col>
+                        </colgroup>
+                        <tr>
+                            <th></th>
+                            <th>Not Recurring</th>
+                            <th>Recurring</th>
+                            <th>Total</th>
+                        </tr>
+                        <tr>
+                            <th>1 Month</th>
+                            <td data-sub-type="1-MONTH-SUB2" data-recurring="0">0</td>
+                            <td data-sub-type="1-MONTH-SUB2" data-recurring="1">0</td>
+                            <td>0</td>
+                        </tr>
+                        <tr>
+                            <th>3 Month</th>
+                            <td data-sub-type="3-MONTH-SUB2" data-recurring="0">0</td>
+                            <td data-sub-type="3-MONTH-SUB2" data-recurring="1">0</td>
+                            <td>0</td>
+                        </tr>
+                        <tr>
+                            <th>Total</th>
+                            <td>0</td>
+                            <td>0</td>
+                            <td>0</td>
+                        </tr>
+                    </table>
+                </div>
+            </div>
+            <div class="col-xxl-3 col-lg-6 col-md-12">
+                <div>
+                    <h4>Tier III</h4>
+                    <table>
+                        <colgroup>
+                            <col>
+                            <col>
+                            <col>
+                            <col>
+                        </colgroup>
+                        <tr>
+                            <th></th>
+                            <th>Not Recurring</th>
+                            <th>Recurring</th>
+                            <th>Total</th>
+                        </tr>
+                        <tr>
+                            <th>1 Month</th>
+                            <td data-sub-type="1-MONTH-SUB3" data-recurring="0">0</td>
+                            <td data-sub-type="1-MONTH-SUB3" data-recurring="1">0</td>
+                            <td>0</td>
+                        </tr>
+                        <tr>
+                            <th>3 Month</th>
+                            <td data-sub-type="3-MONTH-SUB3" data-recurring="0">0</td>
+                            <td data-sub-type="3-MONTH-SUB3" data-recurring="1">0</td>
+                            <td>0</td>
+                        </tr>
+                        <tr>
+                            <th>Total</th>
+                            <td>0</td>
+                            <td>0</td>
+                            <td>0</td>
+                        </tr>
+                    </table>
+                </div>
+            </div>
+            <div class="col-xxl-3 col-lg-6 col-md-12">
+                <div>
+                    <h4>Tier IV</h4>
+                    <table>
+                        <colgroup>
+                            <col>
+                            <col>
+                            <col>
+                            <col>
+                        </colgroup>
+                        <tr>
+                            <th></th>
+                            <th>Not Recurring</th>
+                            <th>Recurring</th>
+                            <th>Total</th>
+                        </tr>
+                        <tr>
+                            <th>1 Month</th>
+                            <td data-sub-type="1-MONTH-SUB4" data-recurring="0">0</td>
+                            <td data-sub-type="1-MONTH-SUB4" data-recurring="1">0</td>
+                            <td>0</td>
+                        </tr>
+                        <tr>
+                            <th>3 Month</th>
+                            <td data-sub-type="3-MONTH-SUB4" data-recurring="0">0</td>
+                            <td data-sub-type="3-MONTH-SUB4" data-recurring="1">0</td>
+                            <td>0</td>
+                        </tr>
+                        <tr>
+                            <th>Total</th>
+                            <td>0</td>
+                            <td>0</td>
+                            <td>0</td>
+                        </tr>
+                    </table>
+                </div>
+            </div>
+        </div>
         <h3 id="income-dates">
             <span id="date-selector">
                 <a href='#'><i class='fas fa-arrow-left'></i></a> <span class='date'></span> <a href='#'><i class='fas fa-arrow-right'></i></a>


### PR DESCRIPTION
The `/admin/income` page now has a section for each sub tier with easily-digestible info related to the number of active subs for that tier.

![Screen Shot 2020-10-27 at 11 01 35 PM](https://user-images.githubusercontent.com/20373896/97400198-ec6d6a80-18ab-11eb-9779-1afc40d0ec99.png)

This PR closes #224.