### PR TITLE
Add config option for chat WebSocket URL

### DIFF
--- a/assets/chat.js
+++ b/assets/chat.js
@@ -4,7 +4,7 @@ import Chat from 'dgg-chat-gui/assets/chat/js/chat'
 
 const script = document.getElementById('chat-include')
 const chat = new Chat({
-    url: `ws${location.protocol === 'https:' ? 's' : ''}://${location.host}/ws`,
+    url: script.getAttribute('data-ws-url'),
     api: {base: `${location.protocol}//${location.host}`},
     cdn: {base: script.getAttribute('data-cdn')},
     cacheKey: script.getAttribute('data-cache-key'),

--- a/config/config.dgg.php
+++ b/config/config.dgg.php
@@ -14,6 +14,7 @@ return [
     'blog'          => ['feed' => 'https://blog.destiny.gg/feed/json'],
     'android'       => ['app' => 'gg.destiny.app.chat'],
     'banAppealUrl'  => 'https://www.destiny.gg/unban',
+    'chatWebSocketUrl' => 'wss://chat.destiny.gg/ws',
 
     'twitch' => [
         'id' => 18074328,

--- a/config/config.php
+++ b/config/config.php
@@ -26,6 +26,7 @@ return [
         'chat' => '/embed/chat'
     ],
 
+    'chatWebSocketUrl' => 'ws://localhost/ws',
     'cdn' => ['domain' => '','protocol' => 'https://'],
     'blog' => ['feed' => ''],
     'reddit' => ['threads' => ''],

--- a/lib/boot.app.php
+++ b/lib/boot.app.php
@@ -11,7 +11,7 @@ use Monolog\Handler\StreamHandler;
 use Monolog\Logger;
 use Monolog\Processor\PsrLogMessageProcessor;
 
-define('_APP_VERSION', '2.22.1'); // auto-generated: 1603951446962
+define('_APP_VERSION', '2.23.0'); // auto-generated: 1604255434303
 define('_BASEDIR', realpath(__DIR__ . '/../'));
 
 $loader = require _BASEDIR . '/vendor/autoload.php';

--- a/lib/boot.test.php
+++ b/lib/boot.test.php
@@ -8,7 +8,7 @@ use Monolog\Handler\StreamHandler;
 use Monolog\Logger;
 use Monolog\Processor\PsrLogMessageProcessor;
 
-define('_APP_VERSION', '2.22.1'); // auto-generated: 1603951446968
+define('_APP_VERSION', '2.23.0'); // auto-generated: 1604255434308
 define('_BASEDIR', realpath(__DIR__ . '/../'));
 
 $loader = require _BASEDIR . '/vendor/autoload.php';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dgg-website",
-  "version": "2.22.1",
+  "version": "2.23.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dgg-website",
-  "version": "2.22.1",
+  "version": "2.23.0",
   "description": "Destiny.gg front-end",
   "main": "destiny",
   "scripts": {

--- a/views/chat.php
+++ b/views/chat.php
@@ -16,6 +16,7 @@ use Destiny\Common\Config;
 <?=Tpl::manifestScript('chat.vendor.js')?>
 <?=Tpl::manifestScript('chat.js', [
     'id' => 'chat-include',
+    'data-ws-url' => Config::$a['chatWebSocketUrl'],
     'data-cache-key' => $this->cacheKey,
     'data-cdn' => Config::cdnv(),
     'data-ban-appeal-url' => Config::$a['banAppealUrl']


### PR DESCRIPTION
Note that [this destinygg/chat PR](https://github.com/destinygg/chat/pull/40) (and an appropriate value for `allowedoriginhost` in chat's `settings.cfg`) is required to connect to chat on a subdomain/different host.