### PR TITLE
Fix issue with chat session renewal

### DIFF
--- a/assets/web/js/bigscreen.js
+++ b/assets/web/js/bigscreen.js
@@ -264,6 +264,6 @@ import $ from 'jquery'
     // When the browser navigation is changed, also happens when you change the hash in the browser
     window.addEventListener('popstate', handleHistoryPopState)
     // The stream status info, pinged every x seconds and on initial start up
-    fetchStreamInfo().always(() => window.setInterval(fetchStreamInfo, 15000))
+    fetchStreamInfo().always(() => window.setInterval(fetchStreamInfo, 90000))
 
 })();

--- a/assets/web/js/web.js
+++ b/assets/web/js/web.js
@@ -219,7 +219,7 @@ const $document = $(document),
                     } catch(ignored){}
                 }
             });
-        }, 15000);
+        }, 90000);
 
     });
 

--- a/lib/Destiny/Chat/ChatRedisService.php
+++ b/lib/Destiny/Chat/ChatRedisService.php
@@ -117,8 +117,8 @@ class ChatRedisService extends Service {
     /**
      * Updates the session ttl so it does not expire
      */
-    public function renewChatSessionExpiration(string $sessionId) {
-        $this->redis->expire("CHAT:session-$sessionId", $this->maxlife);
+    public function renewChatSessionExpiration(string $sessionId): bool {
+        return $this->redis->expire("CHAT:session-$sessionId", $this->maxlife);
     }
 
     public function setChatSession(SessionCredentials $credentials, string $sessionId) {

--- a/lib/boot.app.php
+++ b/lib/boot.app.php
@@ -11,7 +11,7 @@ use Monolog\Handler\StreamHandler;
 use Monolog\Logger;
 use Monolog\Processor\PsrLogMessageProcessor;
 
-define('_APP_VERSION', '2.23.1'); // auto-generated: 1604459130456
+define('_APP_VERSION', '2.23.2'); // auto-generated: 1604688697474
 define('_BASEDIR', realpath(__DIR__ . '/../'));
 
 $loader = require _BASEDIR . '/vendor/autoload.php';

--- a/lib/boot.test.php
+++ b/lib/boot.test.php
@@ -8,7 +8,7 @@ use Monolog\Handler\StreamHandler;
 use Monolog\Logger;
 use Monolog\Processor\PsrLogMessageProcessor;
 
-define('_APP_VERSION', '2.23.1'); // auto-generated: 1604459130462
+define('_APP_VERSION', '2.23.2'); // auto-generated: 1604688697482
 define('_BASEDIR', realpath(__DIR__ . '/../'));
 
 $loader = require _BASEDIR . '/vendor/autoload.php';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dgg-website",
-  "version": "2.23.1",
+  "version": "2.23.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dgg-website",
-  "version": "2.23.1",
+  "version": "2.23.2",
   "description": "Destiny.gg front-end",
   "main": "destiny",
   "scripts": {


### PR DESCRIPTION
Some months ago, we ran into an issue where many users could connect to chat, but couldn't send messages. When they tried, they were greeted with an error message that read `You have to be logged in to use that`. This happened because they didn't have chat sessions, so the chat server couldn't authenticate them.

At the moment, we only create a new chat session for a user if their PHP session is new or expired ([a new PHP session does not contain `UserRole:USER`](https://github.com/destinygg/website/blob/b06247a63a50a169fefc57794b07051a3098c185/lib/Destiny/Common/Authentication/AuthenticationService.php#L171)). Otherwise, we only try to renew their existing chat session ([its Redis TTL is updated](https://github.com/destinygg/website/blob/b06247a63a50a169fefc57794b07051a3098c185/lib/Destiny/Chat/ChatRedisService.php#L117-L122)), which fails if the session doesn't exist in the first place. This means that in a situation where the user has a PHP session, but no chat session, they won't be able to log into chat until their PHP session expires, or they log out and log back in. This scenario is admittedly rare, but can happen much more frequently when coupled with other issues, such as PHP sessions not being garbage collected.

This PR fixes the issue by simply creating a new chat session if renewing it fails.