### PR TITLE
Allow streamer to auth with YouTube scopes to generate API access tokens

### DIFF
--- a/config/config.dgg.php
+++ b/config/config.dgg.php
@@ -29,6 +29,9 @@ return [
     'twitchbroadcaster' => [
         'dgg_user' => 10
     ],
+    'youtube' => [
+        'dgg_user' => 10
+    ],
 
     'cookie' => [
         'domain' => 'www.destiny.gg',

--- a/config/config.php
+++ b/config/config.php
@@ -72,47 +72,47 @@ return [
         'google' => [
             'client_id' => '',
             'client_secret' => '',
-            'redirect_uri' => ''
+            'redirect_uri' => 'https://localhost/auth/google'
         ],
         'youtube' => [
             'client_id' => '',
             'client_secret' => '',
-            'redirect_uri' => ''
+            'redirect_uri' => 'https://localhost/admin/youtube/auth'
         ],
         'twitch' => [
             'client_id' => '',
             'client_secret' => '',
-            'redirect_uri' => ''
+            'redirect_uri' => 'https://localhost/auth/twitch'
         ],
         'twitter' => [
             'client_id' => '',
             'client_secret' => '',
-            'redirect_uri' => ''
+            'redirect_uri' => 'https://localhost/auth/twitter'
         ],
         'reddit' => [
             'client_id' => '',
             'client_secret' => '',
-            'redirect_uri' => ''
+            'redirect_uri' => 'https://localhost/auth/reddit'
         ],
         'discord' => [
             'client_id' => '',
             'client_secret' => '',
-            'redirect_uri' => ''
+            'redirect_uri' => 'https://localhost/auth/discord'
         ],
         'streamlabs' => [
             'client_id' => '',
             'client_secret' => '',
-            'redirect_uri' => ''
+            'redirect_uri' => 'https://localhost/auth/streamlabs'
         ],
         'twitchbroadcaster' => [
             'client_id' => '',
             'client_secret' => '',
-            'redirect_uri' => ''
+            'redirect_uri' => 'https://localhost/admin/twitch/auth'
         ],
         'streamelements' => [
             'client_id' => '',
             'client_secret' => '',
-            'redirect_uri' => ''
+            'redirect_uri' => 'https://localhost/admin/streamelements/auth'
         ]
     ],
 

--- a/config/config.php
+++ b/config/config.php
@@ -74,6 +74,11 @@ return [
             'client_secret' => '',
             'redirect_uri' => ''
         ],
+        'youtube' => [
+            'client_id' => '',
+            'client_secret' => '',
+            'redirect_uri' => ''
+        ],
         'twitch' => [
             'client_id' => '',
             'client_secret' => '',

--- a/config/config.php
+++ b/config/config.php
@@ -6,6 +6,7 @@
 //ini_set('date.timezone', 'UTC');
 
 use Destiny\Common\Authentication\AuthProvider;
+use Monolog\Logger;
 
 return [
     'cacheNamespace' => '_web18',
@@ -26,6 +27,7 @@ return [
         'chat' => '/embed/chat'
     ],
 
+    'logLevel' => Logger::WARNING,
     'chatWebSocketUrl' => 'ws://localhost/ws',
     'cdn' => ['domain' => '','protocol' => 'https://'],
     'blog' => ['feed' => ''],

--- a/config/config.php
+++ b/config/config.php
@@ -159,7 +159,8 @@ return [
     'youtube' => [
         'apikey' => '',
         'playlistId' => '',
-        'user' => ''
+        'user' => '',
+        'dgg_user' => -1
     ],
 
     'analytics' => [

--- a/lib/Destiny/Common/AdminIntegrationController.php
+++ b/lib/Destiny/Common/AdminIntegrationController.php
@@ -37,7 +37,7 @@ abstract class AdminIntegrationController {
 
     public function index(ViewModel $model) {
         $this->afterConstruct();
-        $model->title = 'StreamLabs';
+        $model->title = $this->title;
         $defaultUserId = $this->authenticatedService->getDefaultUserId();
         $defaultUser = $this->authenticatedService->getDefaultUser();
         $auth = $this->authenticatedService->getDefaultAuth();

--- a/lib/Destiny/Common/Authentication/AuthProvider.php
+++ b/lib/Destiny/Common/Authentication/AuthProvider.php
@@ -4,6 +4,7 @@ namespace Destiny\Common\Authentication;
 abstract class AuthProvider {
 
     const GOOGLE = 'google';
+    const YOUTUBE = 'youtube';
     const TWITCH = 'twitch';
     const REDDIT = 'reddit';
     const TWITTER = 'twitter';

--- a/lib/Destiny/Common/Authentication/AuthenticationService.php
+++ b/lib/Destiny/Common/Authentication/AuthenticationService.php
@@ -18,6 +18,7 @@ use Destiny\Common\Utils\CryptoOpenSSL;
 use Destiny\Common\Utils\Date;
 use Destiny\Discord\DiscordAuthHandler;
 use Destiny\Google\GoogleAuthHandler;
+use Destiny\Google\YouTubeAuthHandler;
 use Destiny\Reddit\RedditAuthHandler;
 use Destiny\StreamElements\StreamElementsAuthHandler;
 use Destiny\StreamLabs\StreamLabsAuthHandler;
@@ -427,6 +428,9 @@ class AuthenticationService extends Service {
                 break;
             case AuthProvider::GOOGLE:
                 $authHandler = new GoogleAuthHandler();
+                break;
+            case AuthProvider::YOUTUBE:
+                $authHandler = new YouTubeAuthHandler();
                 break;
             case AuthProvider::REDDIT:
                 $authHandler = new RedditAuthHandler();

--- a/lib/Destiny/Controllers/AdminYouTubeController.php
+++ b/lib/Destiny/Controllers/AdminYouTubeController.php
@@ -1,0 +1,51 @@
+<?php
+namespace Destiny\Controllers;
+
+use Destiny\Common\AdminIntegrationController;
+use Destiny\Common\Annotation\Controller;
+use Destiny\Common\Annotation\HttpMethod;
+use Destiny\Common\Annotation\Route;
+use Destiny\Common\Annotation\Secure;
+use Destiny\Common\ViewModel;
+use Destiny\Google\YouTubeAdminService;
+use Destiny\Google\YouTubeAuthHandler;
+
+/**
+ * @Controller
+ */
+class AdminYouTubeController extends AdminIntegrationController {
+    function afterConstruct() {
+        $this->authHandler = YouTubeAuthHandler::instance();
+        $this->authenticatedService = YouTubeAdminService::instance();
+        $this->title = 'YouTube Integration';
+        $this->index = '/admin/youtube';
+    }
+
+    /**
+     * @Route ("/admin/youtube")
+     * @Secure ({"ADMIN"})
+     * @HttpMethod ({"GET"})
+     */
+    public function index(ViewModel $model): string {
+        parent::index($model);
+        return 'admin/youtube';
+    }
+
+    /**
+     * @Route ("/admin/youtube/authorize")
+     * @Secure ({"ADMIN"})
+     * @HttpMethod ({"GET"})
+     */
+    public function authorize(): string {
+        return parent::authorize();
+    }
+
+    /**
+     * @Route ("/admin/youtube/auth")
+     * @Secure ({"ADMIN"})
+     * @HttpMethod ({"GET"})
+     */
+    public function exchange(array $params): string {
+        return parent::exchange($params);
+    }
+}

--- a/lib/Destiny/Google/GoogleAuthHandler.php
+++ b/lib/Destiny/Google/GoogleAuthHandler.php
@@ -15,7 +15,7 @@ use Destiny\Common\Utils\Http;
  */
 class GoogleAuthHandler extends AbstractAuthHandler {
 
-    private $authBase = 'https://accounts.google.com/o/oauth2';
+    protected $authBase = 'https://accounts.google.com/o/oauth2';
     private $apiBase = 'https://www.googleapis.com/oauth2/v2';
     public $authProvider = AuthProvider::GOOGLE;
 

--- a/lib/Destiny/Google/YouTubeAdminService.php
+++ b/lib/Destiny/Google/YouTubeAdminService.php
@@ -1,0 +1,14 @@
+<?php
+namespace Destiny\Google;
+
+use Destiny\Common\Authentication\AbstractAuthService;
+use Destiny\Common\Authentication\AuthProvider;
+
+class YouTubeAdminService extends AbstractAuthService {
+    public $provider = AuthProvider::YOUTUBE;
+
+    function afterConstruct() {
+        parent::afterConstruct();
+        $this->authHandler = YouTubeAuthHandler::instance();
+    }
+}

--- a/lib/Destiny/Google/YouTubeAuthHandler.php
+++ b/lib/Destiny/Google/YouTubeAuthHandler.php
@@ -2,9 +2,15 @@
 namespace Destiny\Google;
 
 use Destiny\Common\Authentication\AuthProvider;
+use Destiny\Common\Authentication\OAuthResponse;
+use Destiny\Common\Config;
+use Destiny\Common\Exception;
 use Destiny\Common\Session\Session;
+use Destiny\Common\Utils\FilterParams;
+use Destiny\Common\Utils\Http;
 
 class YouTubeAuthHandler extends GoogleAuthHandler {
+    private $apiBase = 'https://www.googleapis.com/youtube/v3';
     public $authProvider = AuthProvider::YOUTUBE;
 
     function getAuthorizationUrl(
@@ -17,5 +23,52 @@ class YouTubeAuthHandler extends GoogleAuthHandler {
         $claims = ''
     ): string {
         return parent::getAuthorizationUrl($scope, $claims);
+    }
+
+    /**
+     * @throws Exception
+     */
+    private function getUserChannelIds(string $accessToken): array {
+        $client = $this->getHttpClient();
+        $response = $client->get("$this->apiBase/channels", [
+            'query' => [
+                'part' => 'snippet,id',
+                'mine' => true
+            ],
+            'headers' => [
+                'User-Agent' => Config::userAgent(),
+                'Authorization' => "Bearer $accessToken"
+            ]
+        ]);
+
+        if ($response->getStatusCode() == Http::STATUS_OK) {
+            return json_decode($response->getBody(), true);
+        }
+
+        throw new Exception('Error getting YouTube channels.');
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function mapTokenResponse(array $token): OAuthResponse {
+        $data = $this->getUserChannelIds($token['access_token']);
+        FilterParams::required($data, 'items');
+
+        if (count($data['items']) < 1) {
+            throw new Exception('No YouTube channels exist.');
+        }
+
+        $firstChannel = $data['items'][0];
+        return new OAuthResponse([
+            'accessToken' => $token['access_token'],
+            'refreshToken' => $token['refresh_token'],
+            'authProvider' => $this->authProvider,
+            'username' => $firstChannel['snippet']['title'],
+            'authId' => $firstChannel['id'],
+            'authDetail' => $firstChannel['snippet']['title'],
+            'authEmail' => '',
+            'verified' => true,
+        ]);
     }
 }

--- a/lib/Destiny/Google/YouTubeAuthHandler.php
+++ b/lib/Destiny/Google/YouTubeAuthHandler.php
@@ -1,0 +1,21 @@
+<?php
+namespace Destiny\Google;
+
+use Destiny\Common\Authentication\AuthProvider;
+use Destiny\Common\Session\Session;
+
+class YouTubeAuthHandler extends GoogleAuthHandler {
+    public $authProvider = AuthProvider::YOUTUBE;
+
+    function getAuthorizationUrl(
+        $scope = [
+            'https://www.googleapis.com/auth/youtube',
+            'https://www.googleapis.com/auth/youtube.channel-memberships.creator',
+            'https://www.googleapis.com/auth/youtube.force-ssl',
+            'https://www.googleapis.com/auth/youtube.readonly'
+        ],
+        $claims = ''
+    ): string {
+        return parent::getAuthorizationUrl($scope, $claims);
+    }
+}

--- a/lib/Destiny/Google/YouTubeAuthHandler.php
+++ b/lib/Destiny/Google/YouTubeAuthHandler.php
@@ -22,7 +22,15 @@ class YouTubeAuthHandler extends GoogleAuthHandler {
         ],
         $claims = ''
     ): string {
-        return parent::getAuthorizationUrl($scope, $claims);
+        $conf = $this->getAuthProviderConf();
+        return "$this->authBase/auth?" . http_build_query([
+            'response_type' => 'code',
+            'scope' => join(' ', $scope),
+            'state' => 'security_token=' . Session::getSessionId(),
+            'client_id' => $conf['client_id'],
+            'redirect_uri' => sprintf($conf['redirect_uri'], $this->authProvider),
+            'access_type' => 'offline'
+        ], null, '&');
     }
 
     /**

--- a/lib/Destiny/Google/YouTubeAuthHandler.php
+++ b/lib/Destiny/Google/YouTubeAuthHandler.php
@@ -40,7 +40,7 @@ class YouTubeAuthHandler extends GoogleAuthHandler {
         $client = $this->getHttpClient();
         $response = $client->get("$this->apiBase/channels", [
             'query' => [
-                'part' => 'snippet,id',
+                'part' => 'snippet,id,statistics',
                 'mine' => true
             ],
             'headers' => [
@@ -67,7 +67,20 @@ class YouTubeAuthHandler extends GoogleAuthHandler {
             throw new Exception('No YouTube channels exist.');
         }
 
-        $firstChannel = $data['items'][0];
+        // Sort the channels by decreasing sub count.
+        $channels = $data['items'];
+        usort($channels, function($a, $b) {
+            $aSubs = $a['statistics']['subscriberCount'];
+            $bSubs = $b['statistics']['subscriberCount'];
+
+            if ($aSubs === $bSubs) {
+                return 0;
+            }
+            return $aSubs < $bSubs ? 1 : -1;
+        });
+
+        // Get the channel with the most subs.
+        $firstChannel = $channels[0];
         return new OAuthResponse([
             'accessToken' => $token['access_token'],
             'refreshToken' => $token['refresh_token'],

--- a/lib/boot.app.php
+++ b/lib/boot.app.php
@@ -11,7 +11,7 @@ use Monolog\Handler\StreamHandler;
 use Monolog\Logger;
 use Monolog\Processor\PsrLogMessageProcessor;
 
-define('_APP_VERSION', '2.24.0'); // auto-generated: 1604794656059
+define('_APP_VERSION', '2.24.1'); // auto-generated: 1604875093661
 define('_BASEDIR', realpath(__DIR__ . '/../'));
 
 $loader = require _BASEDIR . '/vendor/autoload.php';

--- a/lib/boot.app.php
+++ b/lib/boot.app.php
@@ -34,7 +34,7 @@ $app->setLoader($loader);
 // Logging
 try {
     Log::$log = new Logger ('web');
-    Log::$log->pushHandler(new StreamHandler (_BASEDIR . '/log/web.log', Logger::WARNING));
+    Log::$log->pushHandler(new StreamHandler (_BASEDIR . '/log/web.log', Config::$a['logLevel']));
     Log::$log->pushHandler(new DiscordLogHandler(Logger::ERROR));
     Log::$log->pushProcessor(new PsrLogMessageProcessor());
 } catch (Exception $e) {

--- a/lib/boot.app.php
+++ b/lib/boot.app.php
@@ -11,7 +11,7 @@ use Monolog\Handler\StreamHandler;
 use Monolog\Logger;
 use Monolog\Processor\PsrLogMessageProcessor;
 
-define('_APP_VERSION', '2.23.2'); // auto-generated: 1604688697474
+define('_APP_VERSION', '2.24.0'); // auto-generated: 1604794656059
 define('_BASEDIR', realpath(__DIR__ . '/../'));
 
 $loader = require _BASEDIR . '/vendor/autoload.php';

--- a/lib/boot.test.php
+++ b/lib/boot.test.php
@@ -8,7 +8,7 @@ use Monolog\Handler\StreamHandler;
 use Monolog\Logger;
 use Monolog\Processor\PsrLogMessageProcessor;
 
-define('_APP_VERSION', '2.23.2'); // auto-generated: 1604688697482
+define('_APP_VERSION', '2.24.0'); // auto-generated: 1604794656065
 define('_BASEDIR', realpath(__DIR__ . '/../'));
 
 $loader = require _BASEDIR . '/vendor/autoload.php';

--- a/lib/boot.test.php
+++ b/lib/boot.test.php
@@ -8,7 +8,7 @@ use Monolog\Handler\StreamHandler;
 use Monolog\Logger;
 use Monolog\Processor\PsrLogMessageProcessor;
 
-define('_APP_VERSION', '2.24.0'); // auto-generated: 1604794656065
+define('_APP_VERSION', '2.24.1'); // auto-generated: 1604875093667
 define('_BASEDIR', realpath(__DIR__ . '/../'));
 
 $loader = require _BASEDIR . '/vendor/autoload.php';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dgg-website",
-  "version": "2.24.0",
+  "version": "2.24.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dgg-website",
-  "version": "2.23.2",
+  "version": "2.24.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dgg-website",
-  "version": "2.24.0",
+  "version": "2.24.1",
   "description": "Destiny.gg front-end",
   "main": "destiny",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dgg-website",
-  "version": "2.23.2",
+  "version": "2.24.0",
   "description": "Destiny.gg front-end",
   "main": "destiny",
   "scripts": {

--- a/views/admin/youtube.php
+++ b/views/admin/youtube.php
@@ -1,0 +1,75 @@
+<?php
+use Destiny\Common\Config;
+use Destiny\Common\Session\Session;
+use Destiny\Common\Utils\Date;
+use Destiny\Common\Utils\Tpl;
+?>
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <?= Tpl::title($this->title) ?>
+    <?php include 'seg/meta.php' ?>
+    <?= Tpl::manifestLink('web.css') ?>
+</head>
+<body id="admin" class="no-contain">
+
+<div id="page-wrap">
+    <?php include 'seg/nav.php' ?>
+    <?php include 'seg/admin.nav.php' ?>
+
+    <?php if(!empty($this->warning)): ?>
+        <section class="container mb-0">
+            <div class="alert alert-danger alert-dismissable mb-0">
+                <button type="button" class="close" data-dismiss="alert" aria-label="Close">&times;</button>
+                <strong><i class="fas fa-exclamation-triangle"></i> Warning</strong>
+                <div><?= Tpl::out($this->warning) ?></div>
+            </div>
+        </section>
+    <?php endif ?>
+
+    <section class="container">
+        <h3 class="in" data-toggle="collapse" data-target="#details-content">YouTube Integration</h3>
+        <div id="details-content" class="content content-dark collapse show">
+            <div class="ds-block">
+                <div class="form-group">
+                    <a href="/admin/user/<?= Tpl::out($this->user['userId']) ?>/edit"><?= Tpl::out($this->user['username']) ?></a>
+                    <?php if(!empty($this->auth)): ?>
+                        <span class="badge-pill badge-success">Authorized</span>
+                        <p>Last updated <?= Tpl::fromNow(Date::getDateTime($this->auth['createdDate']), Date::STRING_FORMAT_YEAR) ?></p>
+                    <?php else: ?>
+                        <span class="badge-pill badge-danger">Unauthorized</span>
+                    <?php endif; ?>
+                </div>
+            </div>
+
+            <?php if(!empty($this->auth) && $this->auth['userId'] == Session::getCredentials()->getUserId()): ?>
+                <div class="ds-block">
+                    <div>
+                        Access Token: <a href="#accessToken" data-toggle="show">(show)</a>
+                        <code class="collapse" id="accessToken"><?= Tpl::out($this->auth['accessToken']) ?></code>
+                    </div>
+                    <div>
+                        Refresh Token: <a href="#refreshToken" data-toggle="show">(show)</a>
+                        <code class="collapse" id="refreshToken"><?= Tpl::out($this->auth['refreshToken']) ?></code>
+                    </div>
+                </div>
+            <?php endif; ?>
+
+            <div class="ds-block">
+                <a href="/admin/youtube/authorize" class="btn btn-primary">Authorize</a>
+            </div>
+        </div>
+    </section>
+</div>
+
+<?php include 'seg/alerts.php' ?>
+<?php include 'seg/foot.php' ?>
+<?php include 'seg/tracker.php' ?>
+<?=Tpl::manifestScript('runtime.js')?>
+<?=Tpl::manifestScript('common.vendor.js')?>
+<?=Tpl::manifestScript('web.js')?>
+<?=Tpl::manifestScript('admin.js')?>
+
+</body>
+</html>

--- a/views/seg/admin.nav.php
+++ b/views/seg/admin.nav.php
@@ -26,6 +26,7 @@ use Destiny\Common\User\UserRole;
             <?php endif; ?>
             <?php if(Session::hasRole(UserRole::ADMIN)): ?>
                 <li class="breadcrumb-item"><a href="/admin/twitch">Twitch</a></li>
+                <li class="breadcrumb-item"><a href="/admin/youtube">YouTube</a></li>
             <?php endif; ?>
         <?php endif; ?>
 


### PR DESCRIPTION
With this PR, the streamer can authenticate with Google on `/admin/youtube` to generate tokens for use with the YouTube Data and Live Streaming APIs.

![Screen Shot 2020-11-07 at 5 42 08 PM](https://user-images.githubusercontent.com/20373896/98455052-9a84da00-2120-11eb-8e8d-cdf175640017.png)

To deploy this change, you must edit your app on the [Google APIs Console dashboard](https://console.developers.google.com/apis/dashboard) to include the additional scopes, and generate a new set of credentials for the app. The credentials for regular user OAuth/OpenID logins are kept separate.

### Adding scopes
1. Select the project from the dropdown at the top beside the Google APIs logo.
2. Click on `OAuth consent screen` in the sidebar.
3. Click on `EDIT APP`.
4. Click on `SAVE AND CONTINUE` at the bottom to proceed to step 2 (Scopes) and add the scopes below. [1] [2]
```
https://www.googleapis.com/auth/youtube
https://www.googleapis.com/auth/youtube.channel-memberships.creator
https://www.googleapis.com/auth/youtube.force-ssl
https://www.googleapis.com/auth/youtube.readonly
```
5. Click `SAVE AND CONTINUE` until step 4, then `EXIT TO DASHBOARD`.

### Generating new credentials
1. Click on `Credentials` in the left sidebar.
2. Click on `CREATE CREDENTIALS`, then on `OAuth client ID`.
3. Select `Web application` for `Application type` and write anything for `Name`.
4. Add `https://<host>/admin/youtube/auth` as a redirect URI.
5. Complete the process by clicking `CREATE`.
6. Add a `youtube` array to `oauth_providers` in your `config.local.php`.
```
'oauth_providers' => [
    'youtube' => [
        'client_id' => '<client_id>',
        'client_secret' => '<client_secret>',
        'redirect_uri' => '<redirect_uri>'
    ]
]
```

---

[1] Google considers these scopes "sensitive", which means the app must be verified by Google to avoid a warning during authentication that will easily scare users away. However, verification is probably unnecessary with this PR. The warning can be bypassed and the streamer can obviously trust their own website.

[2] One of the scopes is for the `/members` resource, but accessing the resource requires special approval from YouTube. See the blue notice at the top of [this page](https://developers.google.com/youtube/v3/docs/members) for more info.