### PR TITLE
Allow easy switching between embeds while stream is live on multiple platforms

### DIFF
--- a/assets/web/css/style.scss
+++ b/assets/web/css/style.scss
@@ -1816,7 +1816,7 @@ img.tier-4-flair {
     font-size: 0.9em;
 
     #nav-host-pill-name {
-      margin-left: 0.25em;
+      margin: 0 0.75em 0 0.5em;
       text-transform: uppercase;
       max-width: 110px;
       overflow: hidden;
@@ -1826,6 +1826,13 @@ img.tier-4-flair {
     #nav-host-pill-type {
       text-transform: uppercase;
       margin-left: 1em;
+      opacity: 0.5;
+    }
+
+    .divider {
+      height: 60%;
+      width: 1px;
+      background-color: white;
       opacity: 0.5;
     }
 
@@ -1841,6 +1848,14 @@ img.tier-4-flair {
         top: 50%;
         left: 48%;
         transform: translate(-50%, -50%);
+      }
+
+      &.clickable {
+        cursor: pointer;
+
+        &:hover {
+          opacity: 1;
+        }
       }
     }
 

--- a/assets/web/css/style.scss
+++ b/assets/web/css/style.scss
@@ -1788,6 +1788,7 @@ img.tier-4-flair {
 #nav-host-pill {
   display: none;
   cursor: default;
+  height: 42px;
 
   &.embedded,
   &.hosting {
@@ -1829,14 +1830,20 @@ img.tier-4-flair {
     }
 
     #nav-host-pill-icon {
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      margin-right: 0.25em;
+      position: relative;
       height: 100%;
-      width: 32px;
+      width: 35px;
       opacity: 0.5;
+      overflow: hidden;
+
+      & i {
+        position: absolute;
+        top: 50%;
+        left: 48%;
+        transform: translate(-50%, -50%);
+      }
     }
+
   }
 
   &.embedded #nav-host-pill-button {
@@ -1844,6 +1851,47 @@ img.tier-4-flair {
     border: 1px solid #212121;
     background-color: #aa1c1c;
     color: $color-light;
+  }
+}
+
+.animate-icon {
+  &.remove {
+    animation: slide-up-off-screen 300ms;
+  }
+
+  &.add {
+    animation: slide-up-on-screen 300ms;
+  }
+
+  animation-fill-mode: forwards;
+  animation-timing-function: ease-out;
+}
+
+@keyframes slide-up-off-screen {
+  0% {
+    top: 50%;
+    opacity: 1;
+  }
+  40% {
+    opacity: 0;
+  }
+  100% {
+    top: -50%;
+    opacity: 0;
+  }
+}
+
+@keyframes slide-up-on-screen {
+  0% {
+    top: 150%;
+    opacity: 0;
+  }
+  40% {
+    opacity: 0;
+  }
+  100% {
+    top: 50%;
+    opacity: 1;
   }
 }
 

--- a/assets/web/css/style.scss
+++ b/assets/web/css/style.scss
@@ -1829,10 +1829,14 @@ img.tier-4-flair {
     }
 
     #nav-host-pill-icon {
-      margin: 0 0.75em 0 0.5em;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      margin-right: 0.25em;
+      height: 100%;
+      width: 32px;
       opacity: 0.5;
     }
-
   }
 
   &.embedded #nav-host-pill-button {

--- a/assets/web/css/style.scss
+++ b/assets/web/css/style.scss
@@ -1785,12 +1785,6 @@ img.tier-4-flair {
   align-items: center;
 }
 
-
-#nav-host-pill-container {
-  margin: 0.3em 1em;
-  display: flex;
-}
-
 #nav-host-pill {
   display: none;
   cursor: default;
@@ -1808,6 +1802,9 @@ img.tier-4-flair {
   }
 
   #nav-host-pill-button {
+    margin: 0.3em 1em;
+    display: flex;
+
     transition: background-color 150ms linear;
     border: 1px solid #3b3b3b;
     border-top-color: #272727;

--- a/assets/web/js/bigscreen.js
+++ b/assets/web/js/bigscreen.js
@@ -138,6 +138,10 @@ import $ from 'jquery'
     hostPill.right = hostPill.find('#nav-host-pill-name')
     hostPill.icon = hostPill.find('#nav-host-pill-icon')
 
+    if (streams.length > 1) {
+        hostPill.icon.addClass('clickable')
+    }
+
     const embedUrlForEmbedInfo = embedInfo => {
         switch (embedInfo.platform) {
             case 'twitch':
@@ -242,7 +246,7 @@ import $ from 'jquery'
     }
 
     const cycleThroughStreams = function() {
-        if (!streamStatus.live || embedInfo.embeddingOtherContent) {
+        if (streams.length <= 1 || !streamStatus.live || embedInfo.embeddingOtherContent) {
             return true // Pass the click event up to the host pill.
         }
 

--- a/assets/web/js/bigscreen.js
+++ b/assets/web/js/bigscreen.js
@@ -124,8 +124,6 @@ import $ from 'jquery'
         platform: streamWrap.data('platform'),
         title: 'Bigscreen',
         name: streamWrap.data('name'),
-        id: null,
-        url: '/bigscreen',
         parents: streamWrap.data('twitch-parents')
     }
 
@@ -193,14 +191,12 @@ import $ from 'jquery'
             embedInfo.platform = 'twitch'
             embedInfo.title = streamInfo.host['display_name']
             embedInfo.name = streamInfo.host['name']
-            embedInfo.id = streamInfo.host['id']
             window.history.pushState(embedInfo, null, `#twitch/${embedInfo.name}`)
         } else if (embedInfo.embed) {
             embedInfo.embed = false
             embedInfo.platform = defaultEmbedInfo.platform
             embedInfo.title = defaultEmbedInfo.title
             embedInfo.name = defaultEmbedInfo.name
-            embedInfo.id = defaultEmbedInfo.id
             Object.assign(embedInfo, defaultEmbedInfo)
             window.history.pushState(embedInfo, null, `/bigscreen`)
         }
@@ -235,10 +231,9 @@ import $ from 'jquery'
         const hash = str || window.location.hash || ''
         if (hash.length > 0 && hashregex.test(hash)) {
             const res = hash.match(hashregex),
-                id = null,
                 platform = res[1],
                 name = res[2]
-            return {platform, name, id}
+            return {platform, name}
         }
         return null
     }
@@ -250,7 +245,6 @@ import $ from 'jquery'
             embedInfo.platform = parts.platform
             embedInfo.title = parts.name
             embedInfo.name = parts.name
-            embedInfo.id = parts.id
         }
     }
 

--- a/assets/web/js/bigscreen.js
+++ b/assets/web/js/bigscreen.js
@@ -135,26 +135,26 @@ import $ from 'jquery'
     navhostpill.right = navhostpill.container.find('#nav-host-pill-name')
     navhostpill.icon = navhostpill.container.find('#nav-host-pill-icon')
 
-    const updateStreamFrame = function(){
-        let src = ''
-        switch(embedInfo.platform) {
+    const embedUrlForEmbedInfo = embedInfo => {
+        switch (embedInfo.platform) {
             case 'twitch':
-                src = 'https://player.twitch.tv/?' + $.param({ channel: embedInfo.name, parent: embedInfo.parents }, true)
-                break;
+                return 'https://player.twitch.tv/?' + $.param({ channel: embedInfo.name, parent: embedInfo.parents }, true)
             case 'twitch-vod':
-                src = 'https://player.twitch.tv/?' + $.param({ video: embedInfo.name, parent: embedInfo.parents }, true)
-                break;
+                return 'https://player.twitch.tv/?' + $.param({ video: embedInfo.name, parent: embedInfo.parents }, true)
             case 'twitch-clip':
-                src = 'https://clips.twitch.tv/embed?' + $.param({ clip: embedInfo.name, parent: embedInfo.parents }, true)
-                break;
+                return 'https://clips.twitch.tv/embed?' + $.param({ clip: embedInfo.name, parent: embedInfo.parents }, true)
             case 'youtube':
-                src = 'https://www.youtube.com/embed/' + encodeURIComponent(embedInfo.name)
-                break;
+                return 'https://www.youtube.com/embed/' + encodeURIComponent(embedInfo.name)
             case 'youtube-live':
-                src = 'https://www.youtube.com/embed/live_stream?' + $.param({ channel: embedInfo.name })
-                break;
+                return 'https://www.youtube.com/embed/live_stream?' + $.param({ channel: embedInfo.name })
+            default: // unsupported platform
+                return null
         }
-        if (src !== '' && streamframe.attr('src') !== src) { // avoids a flow issue when in
+    }
+
+    const updateStreamFrame = function(){
+        const src = embedUrlForEmbedInfo(embedInfo)
+        if (src && streamframe.attr('src') !== src) { // avoids a flow issue when in
             const frame = streamframe.clone()
             frame.attr('src', src)
             streamframe.replaceWith(frame)

--- a/assets/web/js/bigscreen.js
+++ b/assets/web/js/bigscreen.js
@@ -121,7 +121,6 @@ import $ from 'jquery'
     const streamWrap = $body.find('#stream-wrap')
     const defaultEmbedInfo = {
         platform: streamWrap.data('platform'),
-        title: 'Bigscreen',
         name: streamWrap.data('name'),
         parents: streamWrap.data('twitch-parents')
     }
@@ -176,7 +175,7 @@ import $ from 'jquery'
         } else {
             navhostpill.container.addClass('embedded');
             navhostpill.left.text('EMBED')
-            navhostpill.right.text(embedInfo.title)
+            navhostpill.right.text(embedInfo.name)
             navhostpill.icon.html(iconClose)
         }
         navhostpill.container
@@ -188,13 +187,11 @@ import $ from 'jquery'
         if (!embedInfo.embeddingOtherContent && streamInfo.host) {
             embedInfo.embeddingOtherContent = true
             embedInfo.platform = 'twitch'
-            embedInfo.title = streamInfo.host['display_name']
             embedInfo.name = streamInfo.host['name']
             window.history.pushState(embedInfo, null, `#twitch/${embedInfo.name}`)
         } else if (embedInfo.embeddingOtherContent) {
             embedInfo.embeddingOtherContent = false
             embedInfo.platform = defaultEmbedInfo.platform
-            embedInfo.title = defaultEmbedInfo.title
             embedInfo.name = defaultEmbedInfo.name
             Object.assign(embedInfo, defaultEmbedInfo)
             window.history.pushState(embedInfo, null, `/bigscreen`)
@@ -242,7 +239,6 @@ import $ from 'jquery'
         if (parts) {
             embedInfo.embeddingOtherContent = true
             embedInfo.platform = parts.platform
-            embedInfo.title = parts.name
             embedInfo.name = parts.name
         }
     }

--- a/assets/web/js/bigscreen.js
+++ b/assets/web/js/bigscreen.js
@@ -125,7 +125,7 @@ import $ from 'jquery'
         parents: streamWrap.data('twitch-parents')
     }
 
-    const streamInfo = {live: false, host: null, preview: null},
+    const streamStatus = {live: false, host: null, preview: null},
         embedInfo = Object.assign({ embeddingOtherContent: false }, defaultEmbedInfo),
         navpillclasses = ['embedded','hidden','hosting','online','offline'],
         navhostpill = {container: $body.find('#nav-host-pill')},
@@ -165,13 +165,13 @@ import $ from 'jquery'
     const updateStreamPill = function(){
         navhostpill.container.removeClass(navpillclasses.join(' '))
         if (!embedInfo.embeddingOtherContent) {
-            if (streamInfo.host && !streamInfo.live) {
+            if (streamStatus.host && !streamStatus.live) {
                 navhostpill.container.addClass('hosting');
                 navhostpill.left.text('HOSTING')
-                navhostpill.right.text(streamInfo.host.name)
+                navhostpill.right.text(streamStatus.host.name)
                 navhostpill.icon.html(iconTwitch)
             } else {
-                navhostpill.left.text(streamInfo.live ? 'LIVE' : 'OFFLINE')
+                navhostpill.left.text(streamStatus.live ? 'LIVE' : 'OFFLINE')
                 navhostpill.right.text('Destiny')
                 navhostpill.icon.html(iconTwitch)
             }
@@ -182,15 +182,15 @@ import $ from 'jquery'
             navhostpill.icon.html(iconClose)
         }
         navhostpill.container
-            .toggleClass('online', streamInfo.live)
-            .toggleClass('offline', !!streamInfo.live)
+            .toggleClass('online', streamStatus.live)
+            .toggleClass('offline', !!streamStatus.live)
     }
 
     const toggleEmbedHost = function() {
-        if (!embedInfo.embeddingOtherContent && streamInfo.host) {
+        if (!embedInfo.embeddingOtherContent && streamStatus.host) {
             embedInfo.embeddingOtherContent = true
             embedInfo.platform = 'twitch'
-            embedInfo.name = streamInfo.host['name']
+            embedInfo.name = streamStatus.host['name']
             window.history.pushState(embedInfo, null, `#twitch/${embedInfo.name}`)
         } else if (embedInfo.embeddingOtherContent) {
             embedInfo.embeddingOtherContent = false
@@ -199,7 +199,7 @@ import $ from 'jquery'
             Object.assign(embedInfo, defaultEmbedInfo)
             window.history.pushState(embedInfo, null, `/bigscreen`)
         }
-        updateStreamPill(streamInfo)
+        updateStreamPill(streamStatus)
         updateStreamFrame(embedInfo)
         return false
     }
@@ -208,7 +208,7 @@ import $ from 'jquery'
         return $.ajax({url: '/api/info/stream'})
             .then(data => {
                 const {live, host, preview} = data
-                return Object.assign(streamInfo, {live, host, preview})
+                return Object.assign(streamStatus, {live, host, preview})
             })
             .then(updateStreamPill)
     }
@@ -222,7 +222,7 @@ import $ from 'jquery'
             // else get the state from the history and update embedInfo
             Object.assign(embedInfo, state)
         }
-        updateStreamPill(streamInfo)
+        updateStreamPill(streamStatus)
         updateStreamFrame(embedInfo)
     }
 

--- a/assets/web/js/bigscreen.js
+++ b/assets/web/js/bigscreen.js
@@ -127,7 +127,6 @@ import $ from 'jquery'
 
     const streamStatus = {live: false, host: null, preview: null},
         embedInfo = Object.assign({ embeddingOtherContent: false }, defaultEmbedInfo),
-        navpillclasses = ['embedded','hidden','hosting','online','offline'],
         navhostpill = {container: $body.find('#nav-host-pill')},
         iconTwitch = '<i class="fab fa-fw fa-twitch"></i>',
         iconClose = '<i class="fas fa-fw fa-times-circle"></i>'
@@ -163,10 +162,9 @@ import $ from 'jquery'
     }
 
     const updateStreamPill = function(){
-        navhostpill.container.removeClass(navpillclasses.join(' '))
+        navhostpill.container.removeClass('embedded hidden')
         if (!embedInfo.embeddingOtherContent) {
             if (streamStatus.host && !streamStatus.live) {
-                navhostpill.container.addClass('hosting');
                 navhostpill.left.text('HOSTING')
                 navhostpill.right.text(streamStatus.host.name)
                 navhostpill.icon.html(iconTwitch)
@@ -181,9 +179,6 @@ import $ from 'jquery'
             navhostpill.right.text(embedInfo.name)
             navhostpill.icon.html(iconClose)
         }
-        navhostpill.container
-            .toggleClass('online', streamStatus.live)
-            .toggleClass('offline', !!streamStatus.live)
     }
 
     const toggleEmbedHost = function() {

--- a/assets/web/js/bigscreen.js
+++ b/assets/web/js/bigscreen.js
@@ -128,7 +128,6 @@ import $ from 'jquery'
     const streamStatus = {live: false, host: null, preview: null},
         embedInfo = Object.assign({ embeddingOtherContent: false }, defaultEmbedInfo),
         navhostpill = {container: $body.find('#nav-host-pill')},
-        iconTwitch = '<i class="fab fa-fw fa-twitch"></i>',
         iconClose = '<i class="fas fa-fw fa-times-circle"></i>'
     navhostpill.left = navhostpill.container.find('#nav-host-pill-type')
     navhostpill.right = navhostpill.container.find('#nav-host-pill-name')
@@ -151,6 +150,20 @@ import $ from 'jquery'
         }
     }
 
+    const iconForPlatform = platform => {
+        switch (platform) {
+            case 'twitch':
+            case 'twitch-vod':
+            case 'twitch-clip':
+                return '<i class="fab fa-fw fa-twitch"></i>'
+            case 'youtube':
+            case 'youtube-live':
+                return '<i class="fab fa-fw fa-youtube"></i>'
+            default: // unsupported platform
+                return null
+        }
+    }
+
     const updateStreamFrame = function(){
         const src = embedUrlForEmbedInfo(embedInfo)
         if (src && streamframe.attr('src') !== src) { // avoids a flow issue when in
@@ -167,11 +180,11 @@ import $ from 'jquery'
             if (streamStatus.host && !streamStatus.live) {
                 navhostpill.left.text('HOSTING')
                 navhostpill.right.text(streamStatus.host.name)
-                navhostpill.icon.html(iconTwitch)
+                navhostpill.icon.html(iconForPlatform('twitch'))
             } else {
                 navhostpill.left.text(streamStatus.live ? 'LIVE' : 'OFFLINE')
-                navhostpill.right.text('Destiny')
-                navhostpill.icon.html(iconTwitch)
+                navhostpill.right.text(defaultEmbedInfo.name)
+                navhostpill.icon.html(iconForPlatform(defaultEmbedInfo.platform))
             }
         } else {
             navhostpill.container.addClass('embedded');

--- a/assets/web/js/bigscreen.js
+++ b/assets/web/js/bigscreen.js
@@ -118,11 +118,11 @@ import $ from 'jquery'
     let streamframe = $body.find('#stream-panel iframe')
     const hashregex = /^#(twitch|twitch-vod|twitch-clip|youtube|youtube-live)\/([A-z0-9_\-]{3,64})$/
 
-    const streamWrap = $body.find('#stream-wrap')
+    const streamDetails = $body.find('.stream-details')
     const defaultEmbedInfo = {
-        platform: streamWrap.data('platform'),
-        name: streamWrap.data('name'),
-        parents: streamWrap.data('twitch-parents')
+        platform: streamDetails.data('platform'),
+        name: streamDetails.data('name'),
+        parents: streamDetails.data('twitch-parents')
     }
 
     const streamStatus = {live: false, host: null, preview: null},

--- a/assets/web/js/bigscreen.js
+++ b/assets/web/js/bigscreen.js
@@ -119,7 +119,7 @@ import $ from 'jquery'
     const hashregex = /^#(twitch|twitch-vod|twitch-clip|youtube)\/([A-z0-9_\-]{3,64})$/
 
     const streamWrap = $body.find('#stream-wrap')
-    const embedInfo = {
+    const defaultEmbedInfo = {
         embed: false,
         platform: streamWrap.data('platform'),
         title: 'Bigscreen',
@@ -128,7 +128,7 @@ import $ from 'jquery'
     }
 
     const streamInfo = {live: false, host: null, preview: null},
-        defaultEmbedInfo = Object.assign({}, embedInfo),
+        embedInfo = Object.assign({}, defaultEmbedInfo),
         navpillclasses = ['embedded','hidden','hosting','online','offline'],
         navhostpill = {container: $body.find('#nav-host-pill')},
         iconTwitch = '<i class="fab fa-fw fa-twitch"></i>',

--- a/assets/web/js/bigscreen.js
+++ b/assets/web/js/bigscreen.js
@@ -120,7 +120,6 @@ import $ from 'jquery'
 
     const streamWrap = $body.find('#stream-wrap')
     const defaultEmbedInfo = {
-        embed: false,
         platform: streamWrap.data('platform'),
         title: 'Bigscreen',
         name: streamWrap.data('name'),
@@ -128,7 +127,7 @@ import $ from 'jquery'
     }
 
     const streamInfo = {live: false, host: null, preview: null},
-        embedInfo = Object.assign({}, defaultEmbedInfo),
+        embedInfo = Object.assign({ embeddingOtherContent: false }, defaultEmbedInfo),
         navpillclasses = ['embedded','hidden','hosting','online','offline'],
         navhostpill = {container: $body.find('#nav-host-pill')},
         iconTwitch = '<i class="fab fa-fw fa-twitch"></i>',
@@ -163,7 +162,7 @@ import $ from 'jquery'
 
     const updateStreamPill = function(){
         navhostpill.container.removeClass(navpillclasses.join(' '))
-        if (!embedInfo.embed) {
+        if (!embedInfo.embeddingOtherContent) {
             if (streamInfo.host && !streamInfo.live) {
                 navhostpill.container.addClass('hosting');
                 navhostpill.left.text('HOSTING')
@@ -186,14 +185,14 @@ import $ from 'jquery'
     }
 
     const toggleEmbedHost = function() {
-        if (!embedInfo.embed && streamInfo.host) {
-            embedInfo.embed = true
+        if (!embedInfo.embeddingOtherContent && streamInfo.host) {
+            embedInfo.embeddingOtherContent = true
             embedInfo.platform = 'twitch'
             embedInfo.title = streamInfo.host['display_name']
             embedInfo.name = streamInfo.host['name']
             window.history.pushState(embedInfo, null, `#twitch/${embedInfo.name}`)
-        } else if (embedInfo.embed) {
-            embedInfo.embed = false
+        } else if (embedInfo.embeddingOtherContent) {
+            embedInfo.embeddingOtherContent = false
             embedInfo.platform = defaultEmbedInfo.platform
             embedInfo.title = defaultEmbedInfo.title
             embedInfo.name = defaultEmbedInfo.name
@@ -241,7 +240,7 @@ import $ from 'jquery'
     const updateEmbedInfoWithBrowserLocationHash = function() {
         const parts = parseEmbedHash(window.location.hash)
         if (parts) {
-            embedInfo.embed = true
+            embedInfo.embeddingOtherContent = true
             embedInfo.platform = parts.platform
             embedInfo.title = parts.name
             embedInfo.name = parts.name

--- a/assets/web/js/bigscreen.js
+++ b/assets/web/js/bigscreen.js
@@ -127,11 +127,11 @@ import $ from 'jquery'
 
     const streamStatus = {live: false, host: null, preview: null},
         embedInfo = Object.assign({ embeddingOtherContent: false }, defaultEmbedInfo),
-        navhostpill = {container: $body.find('#nav-host-pill')},
+        navHostPill = $body.find('#nav-host-pill'),
         iconClose = '<i class="fas fa-fw fa-times-circle"></i>'
-    navhostpill.left = navhostpill.container.find('#nav-host-pill-type')
-    navhostpill.right = navhostpill.container.find('#nav-host-pill-name')
-    navhostpill.icon = navhostpill.container.find('#nav-host-pill-icon')
+    navHostPill.left = navHostPill.find('#nav-host-pill-type')
+    navHostPill.right = navHostPill.find('#nav-host-pill-name')
+    navHostPill.icon = navHostPill.find('#nav-host-pill-icon')
 
     const embedUrlForEmbedInfo = embedInfo => {
         switch (embedInfo.platform) {
@@ -175,22 +175,22 @@ import $ from 'jquery'
     }
 
     const updateStreamPill = function(){
-        navhostpill.container.removeClass('embedded hidden')
+        navHostPill.removeClass('embedded hidden')
         if (!embedInfo.embeddingOtherContent) {
             if (streamStatus.host && !streamStatus.live) {
-                navhostpill.left.text('HOSTING')
-                navhostpill.right.text(streamStatus.host.name)
-                navhostpill.icon.html(iconForPlatform('twitch'))
+                navHostPill.left.text('HOSTING')
+                navHostPill.right.text(streamStatus.host.name)
+                navHostPill.icon.html(iconForPlatform('twitch'))
             } else {
-                navhostpill.left.text(streamStatus.live ? 'LIVE' : 'OFFLINE')
-                navhostpill.right.text(defaultEmbedInfo.name)
-                navhostpill.icon.html(iconForPlatform(defaultEmbedInfo.platform))
+                navHostPill.left.text(streamStatus.live ? 'LIVE' : 'OFFLINE')
+                navHostPill.right.text(defaultEmbedInfo.name)
+                navHostPill.icon.html(iconForPlatform(defaultEmbedInfo.platform))
             }
         } else {
-            navhostpill.container.addClass('embedded');
-            navhostpill.left.text('EMBED')
-            navhostpill.right.text(embedInfo.name)
-            navhostpill.icon.html(iconClose)
+            navHostPill.addClass('embedded');
+            navHostPill.left.text('EMBED')
+            navHostPill.right.text(embedInfo.name)
+            navHostPill.icon.html(iconClose)
         }
     }
 
@@ -260,7 +260,7 @@ import $ from 'jquery'
     // Makes it so the browser navigation,
     window.history.replaceState(embedInfo, null, initUrl)
     // When someone clicks the nav UI element
-    navhostpill.container.on('click touch', toggleEmbedHost)
+    navHostPill.on('click touch', toggleEmbedHost)
     // When the browser navigation is changed, also happens when you change the hash in the browser
     window.addEventListener('popstate', handleHistoryPopState)
     // The stream status info, pinged every x seconds and on initial start up

--- a/assets/web/js/bigscreen.js
+++ b/assets/web/js/bigscreen.js
@@ -181,7 +181,7 @@ import $ from 'jquery'
         }
     }
 
-    const updateStreamPill = function() {
+    const updateStreamPill = function(animateIcon = false) {
         hostPill.removeClass('hidden embedded')
 
         if (embedInfo.embeddingOtherContent) {
@@ -197,7 +197,26 @@ import $ from 'jquery'
         } else {
             hostPill.left.text(streamStatus.live ? 'LIVE' : 'OFFLINE')
             hostPill.right.text(embedInfo.name)
-            hostPill.icon.html(iconForPlatform(embedInfo.platform))
+
+            const newIcon = iconForPlatform(embedInfo.platform)
+            if (animateIcon) {
+                const $oldIcon = hostPill.icon.find('i')
+
+                const $newIcon = $(newIcon)
+                hostPill.icon.append($newIcon)
+
+                // Trigger animations.
+                $oldIcon.addClass('animate-icon remove')
+                $newIcon.addClass('animate-icon add')
+
+                // Remove unused class/icon after the animation ends.
+                setTimeout(function() {
+                    $newIcon.removeClass('animate-icon add')
+                    $oldIcon.remove()
+                }, 300)
+            } else {
+                hostPill.icon.html(newIcon)
+            }
         }
     }
 
@@ -233,7 +252,7 @@ import $ from 'jquery'
         }
         Object.assign(embedInfo, streams[activeStreamIndex])
 
-        updateStreamPill()
+        updateStreamPill(true)
         updateStreamFrame()
 
         return false
@@ -245,7 +264,7 @@ import $ from 'jquery'
                 const { live, host, preview } = data
                 return Object.assign(streamStatus, { live, host, preview })
             })
-            .then(updateStreamPill)
+            .then(updateStreamPill())
     }
 
     const handleHistoryPopState = function() {

--- a/assets/web/js/bigscreen.js
+++ b/assets/web/js/bigscreen.js
@@ -116,7 +116,7 @@ import $ from 'jquery'
     // Embedding, hosting and "navhostpill"
     const initUrl = document.location.href // important this is stored before any work is done that may change this value
     let streamframe = $body.find('#stream-panel iframe')
-    const hashregex = /^#(twitch|twitch-vod|twitch-clip|youtube)\/([A-z0-9_\-]{3,64})$/
+    const hashregex = /^#(twitch|twitch-vod|twitch-clip|youtube|youtube-live)\/([A-z0-9_\-]{3,64})$/
 
     const streamWrap = $body.find('#stream-wrap')
     const defaultEmbedInfo = {
@@ -149,6 +149,9 @@ import $ from 'jquery'
                 break;
             case 'youtube':
                 src = 'https://www.youtube.com/embed/' + encodeURIComponent(embedInfo.name)
+                break;
+            case 'youtube-live':
+                src = 'https://www.youtube.com/embed/live_stream?' + $.param({ channel: embedInfo.name })
                 break;
         }
         if (src !== '' && streamframe.attr('src') !== src) { // avoids a flow issue when in

--- a/assets/web/js/bigscreen.js
+++ b/assets/web/js/bigscreen.js
@@ -128,6 +128,8 @@ import $ from 'jquery'
         })
     })
 
+    const displayName = $body.find('.stream-display-name').data('display-name')
+
     const streamStatus = { live: false, host: null, preview: null }
     const embedInfo = { ...streams[activeStreamIndex], embeddingOtherContent: false }
 
@@ -202,7 +204,7 @@ import $ from 'jquery'
             hostPill.icon.html(iconForPlatform('twitch'))
         } else {
             hostPill.left.text(streamStatus.live ? 'LIVE' : 'OFFLINE')
-            hostPill.right.text(embedInfo.name)
+            hostPill.right.text(displayName)
 
             const newIcon = iconForPlatform(embedInfo.platform)
             if (animateIcon) {

--- a/assets/web/js/bigscreen.js
+++ b/assets/web/js/bigscreen.js
@@ -186,7 +186,7 @@ import $ from 'jquery'
     }
 
     const updateStreamPill = function(animateIcon = false) {
-        hostPill.removeClass('hidden embedded')
+        hostPill.removeClass('hidden hosting embedded')
 
         if (embedInfo.embeddingOtherContent) {
             hostPill.addClass('embedded');
@@ -195,6 +195,8 @@ import $ from 'jquery'
             hostPill.right.text(embedInfo.name)
             hostPill.icon.html(closeIcon)
         } else if (streamStatus.host) {
+            hostPill.addClass('hosting');
+
             hostPill.left.text('HOSTING')
             hostPill.right.text(streamStatus.host.name)
             hostPill.icon.html(iconForPlatform('twitch'))
@@ -268,7 +270,7 @@ import $ from 'jquery'
                 const { live, host, preview } = data
                 return Object.assign(streamStatus, { live, host, preview })
             })
-            .then(updateStreamPill())
+            .then(() => updateStreamPill())
     }
 
     const handleHistoryPopState = function() {

--- a/config/config.dgg.php
+++ b/config/config.dgg.php
@@ -9,7 +9,7 @@ return [
     'support_email' => 'contact@destiny.gg',
     'calendar'      => 'i54j4cu9pl4270asok3mqgdrhk@group.calendar.google.com',
     'commerce'      => ['receiver_email' => 'steven.bonnell.ii@gmail.com'],
-    'embed'         => ['stream' => ['platform' => 'twitch', 'name' => 'destiny', 'twitchParents' => ['www.destiny.gg','stage.destiny.gg']]],
+    'embed'         => ['stream' => [['platform' => 'twitch', 'name' => 'destiny', 'twitchParents' => ['www.destiny.gg','stage.destiny.gg']]]],
     'reddit'        => ['threads' => 'https://www.reddit.com/r/destiny/hot.json'],
     'blog'          => ['feed' => 'https://blog.destiny.gg/feed/json'],
     'android'       => ['app' => 'gg.destiny.app.chat'],

--- a/config/config.dgg.php
+++ b/config/config.dgg.php
@@ -16,6 +16,7 @@ return [
     'chatWebSocketUrl' => 'wss://chat.destiny.gg/ws',
 
     'embed' => [
+        'displayName' => 'destiny',
         'stream' => [
             ['platform' => 'twitch', 'name' => 'destiny', 'twitchParents' => ['www.destiny.gg','stage.destiny.gg']],
             ['platform' => 'youtube-live', 'name' => 'UC554eY5jNUfDq3yDOJYirOQ']

--- a/config/config.dgg.php
+++ b/config/config.dgg.php
@@ -9,12 +9,18 @@ return [
     'support_email' => 'contact@destiny.gg',
     'calendar'      => 'i54j4cu9pl4270asok3mqgdrhk@group.calendar.google.com',
     'commerce'      => ['receiver_email' => 'steven.bonnell.ii@gmail.com'],
-    'embed'         => ['stream' => [['platform' => 'twitch', 'name' => 'destiny', 'twitchParents' => ['www.destiny.gg','stage.destiny.gg']]]],
     'reddit'        => ['threads' => 'https://www.reddit.com/r/destiny/hot.json'],
     'blog'          => ['feed' => 'https://blog.destiny.gg/feed/json'],
     'android'       => ['app' => 'gg.destiny.app.chat'],
     'banAppealUrl'  => 'https://www.destiny.gg/unban',
     'chatWebSocketUrl' => 'wss://chat.destiny.gg/ws',
+
+    'embed' => [
+        'stream' => [
+            ['platform' => 'twitch', 'name' => 'destiny', 'twitchParents' => ['www.destiny.gg','stage.destiny.gg']],
+            ['platform' => 'youtube-live', 'name' => 'UC554eY5jNUfDq3yDOJYirOQ']
+        ]
+    ],
 
     'twitch' => [
         'id' => 18074328,

--- a/config/config.php
+++ b/config/config.php
@@ -20,9 +20,11 @@ return [
 
     'embed' => [
         'stream' => [
-            'platform' => '',
-            'name' => '',
-            'twitchParents' => [] // Domains that will embed the stream, e.g., 'www.example.com'. See https://discuss.dev.twitch.tv/t/twitch-embedded-player-updates-in-2020/23956 for more details.
+            [
+                'platform' => '',
+                'name' => '',
+                'twitchParents' => [] // Domains that will embed the stream, e.g., 'www.example.com'. See https://discuss.dev.twitch.tv/t/twitch-embedded-player-updates-in-2020/23956 for more details.
+            ]
         ],
         'chat' => '/embed/chat'
     ],

--- a/lib/Destiny/Tasks/StreamInfo.php
+++ b/lib/Destiny/Tasks/StreamInfo.php
@@ -23,7 +23,10 @@ class StreamInfo implements TaskInterface {
         );
         if (!empty($info)) {
             $cache->save('lasttimeonline', $info['ended_at']);
-            $path = ImageDownloadUtil::download($info['preview'], true);
+
+            if (!empty($info['preview'])) {
+                $path = ImageDownloadUtil::download($info['preview'], true);
+            }
             if (!empty($path)) {
                 $info['preview'] = Config::cdni() . '/' . $path;
             }

--- a/lib/boot.app.php
+++ b/lib/boot.app.php
@@ -11,7 +11,7 @@ use Monolog\Handler\StreamHandler;
 use Monolog\Logger;
 use Monolog\Processor\PsrLogMessageProcessor;
 
-define('_APP_VERSION', '2.24.3'); // auto-generated: 1614316124736
+define('_APP_VERSION', '2.25.0'); // auto-generated: 1614469710310
 define('_BASEDIR', realpath(__DIR__ . '/../'));
 
 $loader = require _BASEDIR . '/vendor/autoload.php';

--- a/lib/boot.test.php
+++ b/lib/boot.test.php
@@ -8,7 +8,7 @@ use Monolog\Handler\StreamHandler;
 use Monolog\Logger;
 use Monolog\Processor\PsrLogMessageProcessor;
 
-define('_APP_VERSION', '2.24.3'); // auto-generated: 1614316124741
+define('_APP_VERSION', '2.25.0'); // auto-generated: 1614469710316
 define('_BASEDIR', realpath(__DIR__ . '/../'));
 
 $loader = require _BASEDIR . '/vendor/autoload.php';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dgg-website",
-  "version": "2.24.3",
+  "version": "2.25.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dgg-website",
-  "version": "2.24.3",
+  "version": "2.25.0",
   "description": "Destiny.gg front-end",
   "main": "destiny",
   "scripts": {

--- a/views/bigscreen.php
+++ b/views/bigscreen.php
@@ -18,8 +18,9 @@ use Destiny\Common\Config;
     <div id="bigscreen-layout">
         <div id="stream-panel">
             <?php foreach (Config::$a['embed']['stream'] as $streamDetails): ?>
-                <div class="stream-details" data-platform="<?= $streamDetails['platform'] ?>" data-name="<?= $streamDetails['name'] ?>" data-twitch-parents="<?= Tpl::arrayOut($streamDetails['twitchParents']) ?>"></div>
-            <?php endforeach ?>
+                <?php $twitchParents = !empty($streamDetails['twitchParents']) ? Tpl::arrayOut($streamDetails['twitchParents']) : ''; ?>
+                <div class="stream-details" data-platform="<?= $streamDetails['platform'] ?>" data-name="<?= $streamDetails['name'] ?>" data-twitch-parents="<?= $twitchParents ?>"></div>
+            <?php endforeach; ?>
             <div id="stream-wrap">
                 <iframe seamless="seamless" allowfullscreen></iframe>
             </div>

--- a/views/bigscreen.php
+++ b/views/bigscreen.php
@@ -17,7 +17,10 @@ use Destiny\Common\Config;
 
     <div id="bigscreen-layout">
         <div id="stream-panel">
-            <div id="stream-wrap" data-platform="<?= Config::$a['embed']['stream']['platform'] ?>" data-name="<?= Config::$a['embed']['stream']['name'] ?>" data-twitch-parents="<?= Tpl::arrayOut(Config::$a['embed']['stream']['twitchParents']) ?>">
+            <?php foreach (Config::$a['embed']['stream'] as $streamDetails): ?>
+                <div class="stream-details" data-platform="<?= $streamDetails['platform'] ?>" data-name="<?= $streamDetails['name'] ?>" data-twitch-parents="<?= Tpl::arrayOut($streamDetails['twitchParents']) ?>"></div>
+            <?php endforeach ?>
+            <div id="stream-wrap">
                 <iframe seamless="seamless" allowfullscreen></iframe>
             </div>
         </div>

--- a/views/bigscreen.php
+++ b/views/bigscreen.php
@@ -17,6 +17,7 @@ use Destiny\Common\Config;
 
     <div id="bigscreen-layout">
         <div id="stream-panel">
+            <div class="stream-display-name" data-display-name="<?= Config::$a['embed']['displayName'] ?>"></div>
             <?php foreach (Config::$a['embed']['stream'] as $streamDetails): ?>
                 <?php $twitchParents = !empty($streamDetails['twitchParents']) ? Tpl::arrayOut($streamDetails['twitchParents']) : ''; ?>
                 <div class="stream-details" data-platform="<?= $streamDetails['platform'] ?>" data-name="<?= $streamDetails['name'] ?>" data-twitch-parents="<?= $twitchParents ?>"></div>

--- a/views/seg/nav.php
+++ b/views/seg/nav.php
@@ -75,6 +75,7 @@ use Destiny\Common\Session\Session;
                     <div id="nav-host-pill-button">
                         <span id="nav-host-pill-type"></span>
                         <span id="nav-host-pill-name"></span>
+                        <div class="divider"></div>
                         <div id="nav-host-pill-icon"></div>
                     </div>
                 </li>

--- a/views/seg/nav.php
+++ b/views/seg/nav.php
@@ -72,12 +72,10 @@ use Destiny\Common\Session\Session;
             <ul class="navbar-nav" id="secondary-navbar">
 
                 <li class="nav-item hidden" id="nav-host-pill">
-                    <div id="nav-host-pill-container">
-                        <div id="nav-host-pill-button">
-                            <span id="nav-host-pill-type"></span>
-                            <span id="nav-host-pill-name"></span>
-                            <div id="nav-host-pill-icon"><i class="fab fa-fw fa-twitch"></i></div>
-                        </div>
+                    <div id="nav-host-pill-button">
+                        <span id="nav-host-pill-type"></span>
+                        <span id="nav-host-pill-name"></span>
+                        <div id="nav-host-pill-icon"></div>
                     </div>
                 </li>
 


### PR DESCRIPTION
https://user-images.githubusercontent.com/20373896/109403661-91a85600-7913-11eb-9cff-fd6b07df2c4d.mov

This PR lets users cycle through embeds by clicking the platform icon in the host pill. It also gives users the ability to embed a YouTube livestream without knowing the stream's specific URL (though you do need the channel's ID 😵). This is done by appending `#youtube-live/<channel_id>` to the URL while on `/bigscreen`.

The `embed => stream` config option is now an array of stream details where each entry needs at least a `platform` and a `name`. I've also added `embed => displayName`, which is the text that will be displayed in the host pill regardless of which stream is being embedded. This is to deal with streams where `name` isn't user-readable.

Before:
```
'embed' => [
    'stream' => [
        'platform' => 'twitch', 'name' => 'joe', 'twitchParents' => ['www.joe.gg']
    ]
]
```

After:
```
'embed' => [
    'displayName' => 'joe',
    'stream' => [
        ['platform' => 'twitch', 'name' => 'joe', 'twitchParents' => ['www.joe.gg']],
        ['platform' => 'youtube-live', 'name' => 'oCGhZvBaWrXXwLrbrU5vASX1']
    ]
]
```