### PR TITLE
Fixes to stream status API and broadcaster user page access

### DIFF
--- a/lib/Destiny/Common/Authentication/AuthenticationService.php
+++ b/lib/Destiny/Common/Authentication/AuthenticationService.php
@@ -20,7 +20,6 @@ use Destiny\Common\Utils\CryptoOpenSSL;
 use Destiny\Common\Utils\Date;
 use Destiny\Discord\DiscordAuthHandler;
 use Destiny\Google\GoogleAuthHandler;
-use Destiny\Google\YouTubeBroadcasterAuthHandler;
 use Destiny\Reddit\RedditAuthHandler;
 use Destiny\Reddit\RedditService;
 use Destiny\StreamElements\StreamElementsAuthHandler;
@@ -29,6 +28,7 @@ use Destiny\Twitch\TwitchAuthHandler;
 use Destiny\Twitch\TwitchBroadcastAuthHandler;
 use Destiny\Twitter\TwitterAuthHandler;
 use Destiny\YouTube\YouTubeMembershipService;
+use Destiny\YouTube\YouTubeBroadcasterAuthHandler;
 
 /**
  * @method static AuthenticationService instance()

--- a/lib/Destiny/Tasks/StreamInfo.php
+++ b/lib/Destiny/Tasks/StreamInfo.php
@@ -13,6 +13,7 @@ use Destiny\Twitch\TwitchWebHookService;
  * @Schedule(frequency=1,period="minute")
  */
 class StreamInfo implements TaskInterface {
+    const CACHE_KEY_LAST_TIME_ONLINE = 'lasttimeonline';
 
     public function execute() {
         $cache = Application::getNsCache();
@@ -22,10 +23,10 @@ class StreamInfo implements TaskInterface {
 
         $info = $twitchApiService->getStreamStatus(
             $twitchChannelId,
-            $cache->fetch('lasttimeonline')
+            $cache->fetch(self::CACHE_KEY_LAST_TIME_ONLINE)
         );
         if (!empty($info)) {
-            $cache->save('lasttimeonline', $info['ended_at']);
+            $cache->save(self::CACHE_KEY_LAST_TIME_ONLINE, $info['ended_at']);
 
             if (!empty($info['preview'])) {
                 $path = ImageDownloadUtil::download($info['preview'], true);

--- a/lib/Destiny/Tasks/StreamInfo.php
+++ b/lib/Destiny/Tasks/StreamInfo.php
@@ -15,6 +15,7 @@ use Destiny\Twitch\TwitchWebHookService;
 class StreamInfo implements TaskInterface {
     const CACHE_KEY_LAST_TIME_ONLINE = 'lasttimeonline';
     const CACHE_KEY_LAST_STREAM_DURATION = 'laststreamduration';
+    const CACHE_KEY_LAST_STREAM_START = 'laststreamstart';
 
     public function execute() {
         $cache = Application::getNsCache();
@@ -25,12 +26,14 @@ class StreamInfo implements TaskInterface {
         $info = $twitchApiService->getStreamStatus(
             $twitchChannelId,
             $cache->fetch(self::CACHE_KEY_LAST_TIME_ONLINE),
-            $cache->fetch(self::CACHE_KEY_LAST_STREAM_DURATION)
+            $cache->fetch(self::CACHE_KEY_LAST_STREAM_DURATION),
+            $cache->fetch(self::CACHE_KEY_LAST_STREAM_START)
         );
         if (!empty($info)) {
             $cache->save(self::CACHE_KEY_LAST_TIME_ONLINE, $info['ended_at']);
             if ($info['live']) {
                 $cache->save(self::CACHE_KEY_LAST_STREAM_DURATION, $info['duration']);
+                $cache->save(self::CACHE_KEY_LAST_STREAM_START, $info['started_at']);
             }
 
             if (!empty($info['preview'])) {

--- a/lib/Destiny/Tasks/StreamInfo.php
+++ b/lib/Destiny/Tasks/StreamInfo.php
@@ -14,6 +14,7 @@ use Destiny\Twitch\TwitchWebHookService;
  */
 class StreamInfo implements TaskInterface {
     const CACHE_KEY_LAST_TIME_ONLINE = 'lasttimeonline';
+    const CACHE_KEY_LAST_STREAM_DURATION = 'laststreamduration';
 
     public function execute() {
         $cache = Application::getNsCache();
@@ -23,10 +24,14 @@ class StreamInfo implements TaskInterface {
 
         $info = $twitchApiService->getStreamStatus(
             $twitchChannelId,
-            $cache->fetch(self::CACHE_KEY_LAST_TIME_ONLINE)
+            $cache->fetch(self::CACHE_KEY_LAST_TIME_ONLINE),
+            $cache->fetch(self::CACHE_KEY_LAST_STREAM_DURATION)
         );
         if (!empty($info)) {
             $cache->save(self::CACHE_KEY_LAST_TIME_ONLINE, $info['ended_at']);
+            if ($info['live']) {
+                $cache->save(self::CACHE_KEY_LAST_STREAM_DURATION, $info['duration']);
+            }
 
             if (!empty($info['preview'])) {
                 $path = ImageDownloadUtil::download($info['preview'], true);

--- a/lib/Destiny/Twitch/TwitchApiService.php
+++ b/lib/Destiny/Twitch/TwitchApiService.php
@@ -159,7 +159,7 @@ class TwitchApiService extends Service {
      * ]
      * @return array|null
      */
-    public function getStreamStatus(int $channelId, string $lastOnline = null) {
+    public function getStreamStatus(int $channelId, string $lastOnline = null, int $lastStreamDuration = null) {
         $channel = $this->getChannel($channelId);
 
         if (empty($channel)) {
@@ -197,7 +197,7 @@ class TwitchApiService extends Service {
             $lastPreview = (!empty($broadcasts) && isset($broadcasts['videos']) && !empty($broadcasts['videos'])) ? $broadcasts['videos'][0]['preview']['medium'] : null;
             $data['preview'] = $lastPreview;
             $data['started_at'] = null;
-            $data['duration'] = 0;
+            $data['duration'] = $lastStreamDuration;
             $data['viewers'] = 0;
 
         }

--- a/lib/Destiny/Twitch/TwitchApiService.php
+++ b/lib/Destiny/Twitch/TwitchApiService.php
@@ -159,7 +159,7 @@ class TwitchApiService extends Service {
      * ]
      * @return array|null
      */
-    public function getStreamStatus(int $channelId, string $lastOnline = null, int $lastStreamDuration = null) {
+    public function getStreamStatus(int $channelId, string $lastOnline = null, int $lastStreamDuration = null, string $streamStartedTime = null) {
         $channel = $this->getChannel($channelId);
 
         if (empty($channel)) {
@@ -196,7 +196,7 @@ class TwitchApiService extends Service {
             $broadcasts = $this->getPastBroadcasts($channelId, 1);
             $lastPreview = (!empty($broadcasts) && isset($broadcasts['videos']) && !empty($broadcasts['videos'])) ? $broadcasts['videos'][0]['preview']['medium'] : null;
             $data['preview'] = $lastPreview;
-            $data['started_at'] = null;
+            $data['started_at'] = $streamStartedTime;
             $data['duration'] = $lastStreamDuration;
             $data['viewers'] = 0;
 

--- a/lib/boot.app.php
+++ b/lib/boot.app.php
@@ -11,7 +11,7 @@ use Monolog\Handler\StreamHandler;
 use Monolog\Logger;
 use Monolog\Processor\PsrLogMessageProcessor;
 
-define('_APP_VERSION', '2.31.3'); // auto-generated: 1622323782580
+define('_APP_VERSION', '2.31.4'); // auto-generated: 1623308846412
 define('_BASEDIR', realpath(__DIR__ . '/../'));
 
 $loader = require _BASEDIR . '/vendor/autoload.php';

--- a/lib/boot.test.php
+++ b/lib/boot.test.php
@@ -8,7 +8,7 @@ use Monolog\Handler\StreamHandler;
 use Monolog\Logger;
 use Monolog\Processor\PsrLogMessageProcessor;
 
-define('_APP_VERSION', '2.31.3'); // auto-generated: 1622323782586
+define('_APP_VERSION', '2.31.4'); // auto-generated: 1623308846418
 define('_BASEDIR', realpath(__DIR__ . '/../'));
 
 $loader = require _BASEDIR . '/vendor/autoload.php';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dgg-website",
-  "version": "2.31.3",
+  "version": "2.31.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "dgg-website",
-      "version": "2.31.3",
+      "version": "2.31.4",
       "license": "SEE LICENSE IN <LICENSE.md>",
       "dependencies": {
         "@fortawesome/fontawesome-free": "^5.15.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dgg-website",
-  "version": "2.31.3",
+  "version": "2.31.4",
   "description": "Destiny.gg front-end",
   "main": "destiny",
   "scripts": {


### PR DESCRIPTION
The stream status API won't return accurate values for Twitch start time and stream duration until the streamer goes online, then offline again.