### PR TITLE
Request Twitch Helix API subscriptions scope

### DIFF
--- a/lib/Destiny/Twitch/TwitchBroadcastAuthHandler.php
+++ b/lib/Destiny/Twitch/TwitchBroadcastAuthHandler.php
@@ -10,7 +10,7 @@ class TwitchBroadcastAuthHandler extends TwitchAuthHandler {
 
     public $authProvider = AuthProvider::TWITCHBROADCAST;
 
-    public function getAuthorizationUrl($scope = ['openid', 'user:read:email', 'channel_subscriptions', 'channel_check_subscription'], $claims = '{"userinfo":{"picture":null, "email":null, "email_verified":null, "preferred_username": null}}'): string {
+    public function getAuthorizationUrl($scope = ['openid', 'channel:read:subscriptions', 'user:read:email', 'channel_subscriptions', 'channel_check_subscription'], $claims = '{"userinfo":{"picture":null, "email":null, "email_verified":null, "preferred_username": null}}'): string {
         return parent::getAuthorizationUrl($scope, $claims);
     }
 

--- a/lib/boot.app.php
+++ b/lib/boot.app.php
@@ -11,7 +11,7 @@ use Monolog\Handler\StreamHandler;
 use Monolog\Logger;
 use Monolog\Processor\PsrLogMessageProcessor;
 
-define('_APP_VERSION', '2.31.4'); // auto-generated: 1623308846412
+define('_APP_VERSION', '2.31.5'); // auto-generated: 1625338546899
 define('_BASEDIR', realpath(__DIR__ . '/../'));
 
 $loader = require _BASEDIR . '/vendor/autoload.php';

--- a/lib/boot.test.php
+++ b/lib/boot.test.php
@@ -8,7 +8,7 @@ use Monolog\Handler\StreamHandler;
 use Monolog\Logger;
 use Monolog\Processor\PsrLogMessageProcessor;
 
-define('_APP_VERSION', '2.31.4'); // auto-generated: 1623308846418
+define('_APP_VERSION', '2.31.5'); // auto-generated: 1625338546902
 define('_BASEDIR', realpath(__DIR__ . '/../'));
 
 $loader = require _BASEDIR . '/vendor/autoload.php';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dgg-website",
-  "version": "2.31.4",
+  "version": "2.31.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "dgg-website",
-      "version": "2.31.4",
+      "version": "2.31.5",
       "license": "SEE LICENSE IN <LICENSE.md>",
       "dependencies": {
         "@fortawesome/fontawesome-free": "^5.15.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dgg-website",
-  "version": "2.31.4",
+  "version": "2.31.5",
   "description": "Destiny.gg front-end",
   "main": "destiny",
   "scripts": {


### PR DESCRIPTION
destinygg/website2/twitchscrape uses the tokens generated when the streamer auths on `/admin/twitch`. We can't convert the project to use the Helix API until we request the `channel:read:subscriptions` scope, which is required for the `/subscriptions` endpoint.