### PR TITLE
Correctly EOL in README and -no-dev flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Then download and install [glue](http://glue.readthedocs.org/) and [composer](ht
 ```shell
 npm install webpack -g
 npm ci
-composer install -no-dev
+composer install --no-dev
 ```
 
 #### You can now build the project.


### PR DESCRIPTION
- Changes EOL characters to `LF` instead of `CRLF` since that's more widely compatible
- Fixes `composer install --no-dev` which was previously `-no-dev`

> I can undo the EOL changes, but I would generally assume you'd prefer LF.